### PR TITLE
[BUILD SUCCESS] 예외 처리 통합 코드 작성

### DIFF
--- a/src/main/java/com/example/demo/domain/auth/AuthenticationManager.java
+++ b/src/main/java/com/example/demo/domain/auth/AuthenticationManager.java
@@ -1,16 +1,13 @@
 package com.example.demo.domain.auth;
 
-import java.io.IOException;
+import static com.example.demo.exception.ExceptionType.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import com.example.demo.dto.ErrorResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.demo.exception.CafegoryException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,33 +16,18 @@ public class AuthenticationManager implements HandlerInterceptor {
 	private final CafegoryTokenManager cafegoryTokenManager;
 
 	@Override
-	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
-		Exception {
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 		try {
 			String accessToken = request.getHeader("Authorization");
 			accessToken = accessToken.replaceFirst("Bearer ", "");
 			boolean isAccessToken = cafegoryTokenManager.isAccessToken(accessToken);
 			if (!isAccessToken) {
-				sendErrorResponse(response, "엑세스 토큰이 아닙니다.");
-				return false;
+				throw new CafegoryException(JWT_DESTROYED);
 			}
 			cafegoryTokenManager.getIdentityId(accessToken);
+			return true;
 		} catch (NullPointerException e) {
-			sendErrorResponse(response, "토큰이 없습니다.");
-			return false;
-		} catch (IllegalArgumentException e) {
-			sendErrorResponse(response, e.getMessage());
-			return false;
+			throw new CafegoryException(TOKEN_NOT_FOUND);
 		}
-		return true;
-	}
-
-	private static void sendErrorResponse(HttpServletResponse response, String errorMessage) throws IOException {
-		ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-		response.setStatus(HttpStatus.UNAUTHORIZED.value());
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setCharacterEncoding("UTF-8");
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.writeValue(response.getWriter(), errorResponse);
 	}
 }

--- a/src/main/java/com/example/demo/domain/auth/JwtCafegoryTokenManager.java
+++ b/src/main/java/com/example/demo/domain/auth/JwtCafegoryTokenManager.java
@@ -49,13 +49,9 @@ public class JwtCafegoryTokenManager implements CafegoryTokenManager {
 
 	@Override
 	public boolean isAccessToken(String token) {
-		try {
-			Claims claims = jwtManager.decode(token);
-			String tokenType = claims.get("tokenType", String.class);
-			return tokenType.equals("access");
-		} catch (Exception e) {
-			return false;
-		}
+		Claims claims = jwtManager.decode(token);
+		String tokenType = claims.get("tokenType", String.class);
+		return tokenType.equals("access");
 	}
 
 	private String makeAccessToken(Map<String, Object> memberInformation, Date issuedAt) {

--- a/src/main/java/com/example/demo/domain/auth/JwtManager.java
+++ b/src/main/java/com/example/demo/domain/auth/JwtManager.java
@@ -1,6 +1,10 @@
 package com.example.demo.domain.auth;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.util.Date;
+
+import com.example.demo.exception.CafegoryException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -48,9 +52,9 @@ public class JwtManager {
 			return claimsJws.getPayload();
 
 		} catch (ExpiredJwtException e) {
-			throw new IllegalArgumentException("JWT 토큰이 만료되었습니다.");
+			throw new CafegoryException(JWT_EXPIRED);
 		} catch (JwtException e) {
-			throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
+			throw new CafegoryException(JWT_DESTROYED);
 		}
 	}
 
@@ -58,9 +62,9 @@ public class JwtManager {
 		String errMessage = "";
 		try {
 			decode(jwtString);
-		} catch (IllegalArgumentException e) {
+		} catch (CafegoryException e) {
 			errMessage = e.getMessage();
 		}
-		return errMessage.equals("JWT 토큰이 만료되었습니다.");
+		return errMessage.equals(JWT_EXPIRED.getErrorMessage());
 	}
 }

--- a/src/main/java/com/example/demo/exception/CafegoryException.java
+++ b/src/main/java/com/example/demo/exception/CafegoryException.java
@@ -1,0 +1,22 @@
+package com.example.demo.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.NonNull;
+
+public class CafegoryException extends RuntimeException {
+	private final ExceptionType exceptionType;
+
+	public CafegoryException(@NonNull ExceptionType exceptionType) {
+		this.exceptionType = exceptionType;
+	}
+
+	@Override
+	public String getMessage() {
+		return exceptionType.getErrorMessage();
+	}
+
+	public HttpStatus getHttpStatus() {
+		return exceptionType.getErrStatus();
+	}
+}

--- a/src/main/java/com/example/demo/exception/CafegoryExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/CafegoryExceptionHandler.java
@@ -1,15 +1,23 @@
 package com.example.demo.exception;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import com.example.demo.dto.ErrorResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 @ControllerAdvice
+@Slf4j
 public class CafegoryExceptionHandler {
 	@ExceptionHandler(CafegoryException.class)
 	public ResponseEntity<ErrorResponse> handle(CafegoryException exception) {
+		PrintWriter printWriter = new PrintWriter(new StringWriter());
+		exception.printStackTrace(printWriter);
 		ErrorResponse errorResponse = new ErrorResponse(exception.getMessage());
 		return ResponseEntity.status(exception.getHttpStatus()).body(errorResponse);
 	}

--- a/src/main/java/com/example/demo/exception/CafegoryExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/CafegoryExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.example.demo.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.example.demo.dto.ErrorResponse;
+
+@ControllerAdvice
+public class CafegoryExceptionHandler {
+	@ExceptionHandler(CafegoryException.class)
+	public ResponseEntity<ErrorResponse> handle(CafegoryException exception) {
+		ErrorResponse errorResponse = new ErrorResponse(exception.getMessage());
+		return ResponseEntity.status(exception.getHttpStatus()).body(errorResponse);
+	}
+}

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -1,0 +1,32 @@
+package com.example.demo.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExceptionType {
+	JWT_EXPIRED(UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
+	JWT_DESTROYED(UNAUTHORIZED, "JWT 토큰이 잘못되었습니다."),
+	TOKEN_NOT_FOUND(UNAUTHORIZED, "토큰이 없습니다."),
+	TOKEN_REFRESH_REJECT(UNAUTHORIZED, "토큰을 재발행할 수 없습니다."),
+	STUDY_ONCE_WRONG_START_TIME(BAD_REQUEST, "카공 시작 시간은 현재 시간보다 최소 3시간 이후여야 합니다."),
+	STUDY_ONCE_SHORT_DURATION(BAD_REQUEST, "카공 시간은 1시간 이상이어야 합니다."),
+	STUDY_ONCE_LONG_DURATION(BAD_REQUEST, "카공 시간은 5시간 미만이어야 합니다."),
+	STUDY_ONCE_TOO_MUCH_STUDY_IN_CAFE(BAD_REQUEST, "이 카페에 이 인원의 카공을 더이상 생성할 수 없습니다."),
+	STUDY_ONCE_CONFLICT_TIME(CONFLICT, "해당 시간에 참여중인 카공이 이미 있습니다."),
+	STUDY_ONCE_DUPLICATE(CONFLICT, "이미 참여중인 카공입니다."),
+	STUDY_ONCE_FULL(CONFLICT, "카공 신청 가능 인원을 초과하였습니다."),
+	STUDY_ONCE_NOT_FOUND(NOT_FOUND, "해당 카공을 찾을 수 없습니다."),
+	STUDY_ONCE_TOO_LATE_JOIN(CONFLICT, "카공 인원 모집이 확정된 이후 참여 신청을 할 수 없습니다."),
+	STUDY_ONCE_TOO_LATE_QUIT(CONFLICT, "카공 인원 모집이 확정된 이후 참여 취소를 할 수 없습니다."),
+	STUDY_ONCE_TRY_QUIT_NOT_JOIN(CONFLICT, "참여중인 카공이 아닙니다."),
+	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
+	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다.");
+	private final HttpStatus errStatus;
+	private final String errorMessage;
+}

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -26,7 +26,8 @@ public enum ExceptionType {
 	STUDY_ONCE_TOO_LATE_QUIT(CONFLICT, "카공 인원 모집이 확정된 이후 참여 취소를 할 수 없습니다."),
 	STUDY_ONCE_TRY_QUIT_NOT_JOIN(CONFLICT, "참여중인 카공이 아닙니다."),
 	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
-	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다.");
+	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다."),
+	CAFE_NOT_FOUND(NOT_FOUND, "없는 카페입니다.");
 	private final HttpStatus errStatus;
 	private final String errorMessage;
 }

--- a/src/main/java/com/example/demo/service/OAuth2ServiceImpl.java
+++ b/src/main/java/com/example/demo/service/OAuth2ServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.demo.service;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -14,6 +16,7 @@ import com.example.demo.dto.auth.CafegoryToken;
 import com.example.demo.dto.oauth2.OAuth2Profile;
 import com.example.demo.dto.oauth2.OAuth2Token;
 import com.example.demo.dto.oauth2.OAuth2TokenRequest;
+import com.example.demo.exception.CafegoryException;
 import com.example.demo.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -45,7 +48,7 @@ public class OAuth2ServiceImpl implements OAuth2Service {
 			long identityId = cafegoryTokenManager.getIdentityId(refreshToken);
 			return makeCafegoryToken(identityId);
 		}
-		throw new IllegalArgumentException("토큰을 재발행할 수 없습니다.");
+		throw new CafegoryException(TOKEN_REFRESH_REJECT);
 	}
 
 	private CafegoryToken makeCafegoryToken(long memberId) {

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -100,7 +100,8 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 
 	@Override
 	public StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest) {
-		CafeImpl cafe = cafeRepository.findById(studyOnceCreateRequest.getCafeId()).orElseThrow();
+		CafeImpl cafe = cafeRepository.findById(studyOnceCreateRequest.getCafeId())
+			.orElseThrow(() -> new CafegoryException(CAFE_NOT_FOUND));
 		//ToDo 카페 영업시간 이내인지 확인 하는 작업 추가 필요
 		LocalDateTime startDateTime = studyOnceCreateRequest.getStartDateTime();
 		MemberImpl leader = getMember(leaderId, startDateTime);
@@ -111,7 +112,8 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	private MemberImpl getMember(long leaderId, LocalDateTime startDateTime) {
-		MemberImpl leader = memberRepository.findById(leaderId).orElseThrow();
+		MemberImpl leader = memberRepository.findById(leaderId)
+			.orElseThrow(() -> new CafegoryException(MEMBER_NOT_FOUND));
 		var studyMembers = studyMemberRepository.findByMemberAndStudyDate(leader, startDateTime.toLocalDate());
 		leader.setStudyMembers(studyMembers);
 		return leader;

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.demo.service;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +18,7 @@ import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
 import com.example.demo.dto.UpdateAttendanceResponse;
+import com.example.demo.exception.CafegoryException;
 import com.example.demo.repository.MemberRepository;
 import com.example.demo.repository.StudyMemberRepository;
 import com.example.demo.repository.StudyOnceRepository;
@@ -36,7 +39,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	@Override
 	public void tryJoin(long memberIdThatExpectedToJoin, long studyId) {
 		StudyOnceImpl studyOnce = studyOnceRepository.findById(studyId)
-			.orElseThrow(() -> new IllegalArgumentException("없는 카공입니다."));
+			.orElseThrow(() -> new CafegoryException(STUDY_ONCE_NOT_FOUND));
 		LocalDateTime startDateTime = studyOnce.getStartDateTime();
 		MemberImpl member = getMember(memberIdThatExpectedToJoin, startDateTime);
 		studyOnce.tryJoin(member, LocalDateTime.now());
@@ -45,9 +48,9 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	@Override
 	public void tryQuit(long memberIdThatExpectedToQuit, long studyId) {
 		MemberImpl member = memberRepository.findById(memberIdThatExpectedToQuit)
-			.orElseThrow(() -> new IllegalArgumentException("없는 회원입니다."));
+			.orElseThrow(() -> new CafegoryException(MEMBER_NOT_FOUND));
 		StudyOnceImpl studyOnce = studyOnceRepository.findById(studyId)
-			.orElseThrow(() -> new IllegalArgumentException("없는 카공입니다."));
+			.orElseThrow(() -> new CafegoryException(STUDY_ONCE_NOT_FOUND));
 		if (studyOnce.getLeader().equals(member)) {
 			deleteStudy(studyOnce);
 		}
@@ -57,7 +60,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 
 	private void deleteStudy(StudyOnceImpl studyOnce) {
 		if (studyOnce.getStudyMembers().size() > 1) {
-			throw new IllegalStateException("카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다.");
+			throw new CafegoryException(STUDY_ONCE_LEADER_QUIT_FAIL);
 		}
 		studyOnceRepository.delete(studyOnce);
 	}
@@ -85,7 +88,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	@Override
 	public StudyOnceSearchResponse searchByStudyId(long studyId) {
 		StudyOnceImpl searched = studyOnceRepository.findById(studyId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 카공을 찾을 수 없습니다."));
+			.orElseThrow(() -> new CafegoryException(STUDY_ONCE_NOT_FOUND));
 		boolean canJoin = searched.canJoin(LocalDateTime.now());
 		return makeStudyOnceSearchResponse(searched, canJoin);
 	}

--- a/src/test/java/com/example/demo/domain/StudyOnceImplTest.java
+++ b/src/test/java/com/example/demo/domain/StudyOnceImplTest.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import com.example.demo.exception.CafegoryException;
 
 class StudyOnceImplTest {
 	static final LocalDateTime NOW = LocalDateTime.now();
@@ -88,8 +92,8 @@ class StudyOnceImplTest {
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		org.assertj.core.api.Assertions.assertThatThrownBy(
 				() -> studyOnce.tryJoin(member, NOW.plusHours(3).plusSeconds(1)))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("카공 인원 모집이 확정된 이후 참여 신청을 할 수 없습니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_TOO_LATE_JOIN.getErrorMessage());
 	}
 
 	@Test
@@ -99,8 +103,8 @@ class StudyOnceImplTest {
 		MemberImpl member = makeMember(2, NOW.plusHours(9), NOW.plusHours(13));
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(5), NOW.plusHours(9));
 		org.assertj.core.api.Assertions.assertThatThrownBy(() -> studyOnce.tryJoin(member, NOW))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("해당 시간에 참여중인 카공이 이미 있습니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_CONFLICT_TIME.getErrorMessage());
 	}
 
 	@Test
@@ -111,8 +115,8 @@ class StudyOnceImplTest {
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		studyOnce.tryJoin(member, NOW);
 		org.assertj.core.api.Assertions.assertThatThrownBy(() -> studyOnce.tryJoin(member, NOW))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("이미 참여중인 카공입니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_DUPLICATE.getErrorMessage());
 	}
 
 	@Test
@@ -134,8 +138,8 @@ class StudyOnceImplTest {
 		studyOnce.tryJoin(member, NOW);
 		org.assertj.core.api.Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW.plusHours(3).plusSeconds(1)))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("카공 인원 모집이 확정된 이후 참여 취소를 할 수 없습니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_TOO_LATE_QUIT.getErrorMessage());
 	}
 
 	@Test
@@ -146,7 +150,7 @@ class StudyOnceImplTest {
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		org.assertj.core.api.Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("참여중인 카공이 아닙니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_TRY_QUIT_NOT_JOIN.getErrorMessage());
 	}
 }

--- a/src/test/java/com/example/demo/domain/StudyOnceImplTest.java
+++ b/src/test/java/com/example/demo/domain/StudyOnceImplTest.java
@@ -19,6 +19,8 @@ import com.example.demo.exception.CafegoryException;
 
 class StudyOnceImplTest {
 	static final LocalDateTime NOW = LocalDateTime.now();
+	static final long LEADER_ID = 1L;
+	static final long MEMBER_ID = 2L;
 
 	@ParameterizedTest
 	@MethodSource("canJoinParameter")
@@ -37,7 +39,7 @@ class StudyOnceImplTest {
 	@DisplayName("정상적으로 생성되었을 때 의존성 제대로 설정되었는지 확인하는 테스트")
 	void create() {
 		LocalDateTime start = NOW.plusHours(3).plusMinutes(1);
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
 		StudyOnceImpl studyOnce = StudyOnceImpl.builder()
 			.startDateTime(start)
 			.endDateTime(start.plusHours(4))
@@ -58,8 +60,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("카공 참여 테스트")
 	void tryJoin() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = makeMember(2, NOW.plusHours(9), NOW.plusHours(13));
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
 		List<MemberImpl> collect = studyOnce.getStudyMembers()
@@ -77,8 +79,8 @@ class StudyOnceImplTest {
 			.build();
 	}
 
-	private static MemberImpl makeMember(long memberId, LocalDateTime start, LocalDateTime end) {
-		MemberImpl member = MemberImpl.builder().id(memberId).build();
+	private static MemberImpl makeMemberWithStudyOnce(LocalDateTime start, LocalDateTime end) {
+		MemberImpl member = MemberImpl.builder().id(MEMBER_ID).build();
 		StudyMember studyMember = new StudyMember(member, makeStudy(member, start, end));
 		member.setStudyMembers(new ArrayList<>(List.of(studyMember)));
 		return member;
@@ -87,8 +89,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("이미 카공 참여 인원이 확정되어 카공 참여 실패하는 테스트")
 	void tryJoinFailByTimeOver() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = MemberImpl.builder().id(2L).build();
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = MemberImpl.builder().id(MEMBER_ID).build();
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		org.assertj.core.api.Assertions.assertThatThrownBy(
 				() -> studyOnce.tryJoin(member, NOW.plusHours(3).plusSeconds(1)))
@@ -99,8 +101,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("이미 참여중인 카공이 있어서 실패하는 테스트")
 	void tryJoinFailByConflict() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = makeMember(2, NOW.plusHours(9), NOW.plusHours(13));
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(5), NOW.plusHours(9));
 		org.assertj.core.api.Assertions.assertThatThrownBy(() -> studyOnce.tryJoin(member, NOW))
 			.isInstanceOf(CafegoryException.class)
@@ -110,8 +112,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("이미 참여중인 카공이라 실패하는 테스트")
 	void tryJoinFailByDuplicate() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = makeMember(2, NOW.plusHours(9), NOW.plusHours(13));
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		studyOnce.tryJoin(member, NOW);
 		org.assertj.core.api.Assertions.assertThatThrownBy(() -> studyOnce.tryJoin(member, NOW))
@@ -122,8 +124,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("카공 참여 취소 테스트")
 	void tryQuit() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = MemberImpl.builder().id(2L).build();
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = MemberImpl.builder().id(MEMBER_ID).build();
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		studyOnce.tryJoin(member, NOW);
 		studyOnce.tryQuit(member, NOW.plusHours(3).minusSeconds(1));
@@ -132,8 +134,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("이미 카공 참여 인원이 확정되어 카공 참여 취소가 실패하는 테스트")
 	void tryQuitFailByTimeOver() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = MemberImpl.builder().id(2L).build();
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = MemberImpl.builder().id(MEMBER_ID).build();
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		studyOnce.tryJoin(member, NOW);
 		org.assertj.core.api.Assertions.assertThatThrownBy(
@@ -145,8 +147,8 @@ class StudyOnceImplTest {
 	@Test
 	@DisplayName("참여중인 카공이 아니라서 카공 참여 취소가 실패하는 테스트")
 	void tryQuitFailByNotJoin() {
-		MemberImpl leader = MemberImpl.builder().id(1L).build();
-		MemberImpl member = MemberImpl.builder().id(2L).build();
+		MemberImpl leader = MemberImpl.builder().id(LEADER_ID).build();
+		MemberImpl member = MemberImpl.builder().id(MEMBER_ID).build();
 		StudyOnceImpl studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
 		org.assertj.core.api.Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW))

--- a/src/test/java/com/example/demo/domain/auth/JwtCafegoryTokenManagerTest.java
+++ b/src/test/java/com/example/demo/domain/auth/JwtCafegoryTokenManagerTest.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.auth;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.example.demo.dto.auth.CafegoryToken;
+import com.example.demo.exception.CafegoryException;
 
 class JwtCafegoryTokenManagerTest {
 	private final String testSecret = "01234567890123456789012345678901234567890123456789";
@@ -106,7 +109,7 @@ class JwtCafegoryTokenManagerTest {
 	private String makeAccessToken() {
 		jwtManager.claim("memberId", "1");
 		jwtManager.claim("tokenType", "access");
-		jwtManager.setLife(Date.from(Instant.now()), 0);
+		jwtManager.setLife(Date.from(Instant.now()), 10000);
 		return jwtManager.make();
 	}
 
@@ -136,8 +139,9 @@ class JwtCafegoryTokenManagerTest {
 	void canRefreshFalseCauseRefreshTokenExpired() {
 		String refreshToken = makeExpiredRefreshToken();
 		JwtCafegoryTokenManager jwtCafegoryTokenManager = new JwtCafegoryTokenManager(jwtManager);
-		boolean canRefresh = jwtCafegoryTokenManager.canRefresh(refreshToken);
-		Assertions.assertThat(canRefresh).isEqualTo(false);
+		Assertions.assertThatThrownBy(() -> jwtCafegoryTokenManager.canRefresh(refreshToken))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(JWT_EXPIRED.getErrorMessage());
 	}
 
 	private String makeExpiredRefreshToken() {

--- a/src/test/java/com/example/demo/domain/auth/JwtCafegoryTokenManagerTest.java
+++ b/src/test/java/com/example/demo/domain/auth/JwtCafegoryTokenManagerTest.java
@@ -63,11 +63,12 @@ class JwtCafegoryTokenManagerTest {
 	@Test
 	@DisplayName("토큰에서 인증 식별자 추출 테스트")
 	void getIdentityId() {
-		CafegoryToken token = createToken(1);
+		long id = 1L;
+		CafegoryToken token = createToken(id);
 		String accessToken = token.getAccessToken();
 		JwtCafegoryTokenManager jwtCafegoryTokenManager = new JwtCafegoryTokenManager(jwtManager);
 		long identityId = jwtCafegoryTokenManager.getIdentityId(accessToken);
-		Assertions.assertThat(identityId).isEqualTo(1);
+		Assertions.assertThat(identityId).isEqualTo(id);
 	}
 
 	private CafegoryToken createToken(long id) {

--- a/src/test/java/com/example/demo/domain/auth/JwtManagerTest.java
+++ b/src/test/java/com/example/demo/domain/auth/JwtManagerTest.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.auth;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.demo.exception.CafegoryException;
 
 @ExtendWith(MockitoExtension.class)
 class JwtManagerTest {
@@ -59,8 +63,8 @@ class JwtManagerTest {
 		jwtManager.setLife(Date.from(Instant.now()), 0);
 		String jwt = jwtManager.make();
 		Assertions.assertThatThrownBy(() -> jwtManager.decode(jwt))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("JWT 토큰이 만료되었습니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(JWT_EXPIRED.getErrorMessage());
 	}
 
 	@Test
@@ -73,8 +77,8 @@ class JwtManagerTest {
 		jwtManager.setLife(Date.from(Instant.now()), 0);
 		String jwt = jwtManager.make() + "34gvagafdga";
 		Assertions.assertThatThrownBy(() -> jwtManager.decode(jwt))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("JWT 토큰이 잘못되었습니다.");
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(JWT_DESTROYED.getErrorMessage());
 	}
 
 	@ParameterizedTest

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -1,12 +1,14 @@
 package com.example.demo.service;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,6 +26,7 @@ import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
+import com.example.demo.exception.CafegoryException;
 
 @SpringBootTest
 @Transactional
@@ -69,7 +72,7 @@ class StudyOnceServiceImplTest {
 
 		//then
 		List<StudyOnceSearchResponse> results = pagedResponse.getList();
-		org.assertj.core.api.Assertions.assertThat(results).contains(expectedStudyOnceSearchResponse);
+		Assertions.assertThat(results).contains(expectedStudyOnceSearchResponse);
 	}
 
 	@Test
@@ -82,7 +85,7 @@ class StudyOnceServiceImplTest {
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		StudyOnceSearchResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		StudyOnceSearchResponse studyOnceSearchResponse = studyOnceService.searchByStudyId(result.getId());
-		Assertions.assertEquals(result.getId(), studyOnceSearchResponse.getId());
+		Assertions.assertThat(studyOnceSearchResponse.getId()).isEqualTo(result.getId());
 	}
 
 	@Test
@@ -95,7 +98,7 @@ class StudyOnceServiceImplTest {
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		StudyOnceSearchResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		StudyOnceSearchResponse expected = makeExpectedStudyOnceCreateResult(cafeId, studyOnceCreateRequest, result);
-		Assertions.assertEquals(expected, result);
+		Assertions.assertThat(result).isEqualTo(expected);
 	}
 
 	private static StudyOnceCreateRequest makeStudyOnceCreateRequest(LocalDateTime start, LocalDateTime end,
@@ -111,32 +114,35 @@ class StudyOnceServiceImplTest {
 		long cafeId = initCafe();
 		long leaderId = initMember();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> studyOnceService.createStudy(leaderId, studyOnceCreateRequest));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(leaderId, studyOnceCreateRequest))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_WRONG_START_TIME.getErrorMessage());
 	}
 
 	@Test
 	@DisplayName("카공 시작 시간과 종료시간 차이가 1시간 미만일 경우 실패")
 	void createFailByStartTimeAndEndTimePeriodIsTooShort() {
-		LocalDateTime start = LocalDateTime.now().minusSeconds(1);
-		LocalDateTime end = start.plusMinutes(59);
+		LocalDateTime start = LocalDateTime.now().plusHours(3).plusMinutes(1);
+		LocalDateTime end = start.plusMinutes(59).plusSeconds(59);
 		long cafeId = initCafe();
 		long leaderId = initMember();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> studyOnceService.createStudy(leaderId, studyOnceCreateRequest));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(leaderId, studyOnceCreateRequest))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_SHORT_DURATION.getErrorMessage());
 	}
 
 	@Test
 	@DisplayName("카공 시작 시간과 종료시간 차이가 5시간 초과일 경우 실패")
 	void createFailByStartTimeAndEndTimePeriodIsTooLong() {
-		LocalDateTime start = LocalDateTime.now().minusSeconds(1);
+		LocalDateTime start = LocalDateTime.now().plusHours(3).plusMinutes(1);
 		LocalDateTime end = start.plusHours(5).plusSeconds(1);
 		long cafeId = initCafe();
 		long leaderId = initMember();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		Assertions.assertThrows(IllegalArgumentException.class,
-			() -> studyOnceService.createStudy(leaderId, studyOnceCreateRequest));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(leaderId, studyOnceCreateRequest))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_LONG_DURATION.getErrorMessage());
 	}
 
 	private static StudyOnceSearchResponse makeExpectedStudyOnceCreateResult(long cafeId,
@@ -172,15 +178,17 @@ class StudyOnceServiceImplTest {
 		LocalDateTime rightLimitEnd = rightLimitStart.plusHours(1);
 		StudyOnceCreateRequest needToFailStudyOnceCreateRequest = makeStudyOnceCreateRequest(rightLimitStart,
 			rightLimitEnd, cafeId);
-		Assertions.assertThrows(IllegalStateException.class,
-			() -> studyOnceService.createStudy(leaderId, needToFailStudyOnceCreateRequest));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(leaderId, needToFailStudyOnceCreateRequest))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_CONFLICT_TIME.getErrorMessage());
 		// 왼쪽에서 겹침
 		LocalDateTime leftLimitEnd = start;
 		LocalDateTime leftLimitStart = leftLimitEnd.minusHours(3);
 		StudyOnceCreateRequest needToFailStudyOnceCreateRequest2 = makeStudyOnceCreateRequest(leftLimitStart,
 			leftLimitEnd, cafeId);
-		Assertions.assertThrows(IllegalStateException.class,
-			() -> studyOnceService.createStudy(leaderId, needToFailStudyOnceCreateRequest2));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(leaderId, needToFailStudyOnceCreateRequest2))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_CONFLICT_TIME.getErrorMessage());
 	}
 
 	@Test
@@ -199,15 +207,17 @@ class StudyOnceServiceImplTest {
 		LocalDateTime rightLimitEnd = rightLimitStart.plusHours(1);
 		StudyOnceCreateRequest needToFailStudyOnceCreateRequest = makeStudyOnceCreateRequest(rightLimitStart,
 			rightLimitEnd, cafeId);
-		Assertions.assertThrows(IllegalStateException.class,
-			() -> studyOnceService.createStudy(memberId, needToFailStudyOnceCreateRequest));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(memberId, needToFailStudyOnceCreateRequest))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_CONFLICT_TIME.getErrorMessage());
 		// 왼쪽에서 겹침
 		LocalDateTime leftLimitEnd = start;
 		LocalDateTime leftLimitStart = leftLimitEnd.minusHours(3);
 		StudyOnceCreateRequest needToFailStudyOnceCreateRequest2 = makeStudyOnceCreateRequest(leftLimitStart,
 			leftLimitEnd, cafeId);
-		Assertions.assertThrows(IllegalStateException.class,
-			() -> studyOnceService.createStudy(memberId, needToFailStudyOnceCreateRequest2));
+		Assertions.assertThatThrownBy(() -> studyOnceService.createStudy(memberId, needToFailStudyOnceCreateRequest2))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_CONFLICT_TIME.getErrorMessage());
 	}
 
 	@Test
@@ -258,10 +268,9 @@ class StudyOnceServiceImplTest {
 		//when
 		studyOnceService.tryJoin(secondMemberId, study.getId());
 		//then
-		org.assertj.core.api.Assertions.assertThatThrownBy(
-				() -> studyOnceService.tryJoin(secondMemberId, study.getId()))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("이미 참여중인 카공입니다.");
+		Assertions.assertThatThrownBy(() -> studyOnceService.tryJoin(secondMemberId, study.getId()))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_DUPLICATE.getErrorMessage());
 	}
 
 	@ParameterizedTest
@@ -283,10 +292,9 @@ class StudyOnceServiceImplTest {
 		StudyOnceSearchResponse conflictStudy = studyOnceService.createStudy(thirdMemberId,
 			conflictStudyOnceCreateRequest);
 		//then
-		org.assertj.core.api.Assertions.assertThatThrownBy(
-				() -> studyOnceService.tryJoin(secondMemberId, conflictStudy.getId()))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("해당 시간에 참여중인 카공이 이미 있습니다.");
+		Assertions.assertThatThrownBy(() -> studyOnceService.tryJoin(secondMemberId, conflictStudy.getId()))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_CONFLICT_TIME.getErrorMessage());
 	}
 
 	static Stream<Arguments> tryJoinFailCauseConflictParameters() {
@@ -320,10 +328,9 @@ class StudyOnceServiceImplTest {
 		long cafeId = initCafe();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
-		org.assertj.core.api.Assertions.assertThatThrownBy(
-				() -> studyOnceService.tryQuit(secondMemberId, study.getId()))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("참여중인 카공이 아닙니다.");
+		Assertions.assertThatThrownBy(() -> studyOnceService.tryQuit(secondMemberId, study.getId()))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_TRY_QUIT_NOT_JOIN.getErrorMessage());
 	}
 
 	@Test
@@ -337,9 +344,8 @@ class StudyOnceServiceImplTest {
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 		studyOnceService.tryJoin(secondMemberId, study.getId());
-		org.assertj.core.api.Assertions.assertThatThrownBy(
-				() -> studyOnceService.tryQuit(firstMemberId, study.getId()))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다.");
+		Assertions.assertThatThrownBy(() -> studyOnceService.tryQuit(firstMemberId, study.getId()))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_LEADER_QUIT_FAIL.getErrorMessage());
 	}
 }


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항
#42 예외 처리 기능 추가
1. 커스텀 예외인 `CafegoryException` 추가.
    - API 응답으로 제공되는 예외적인 상황을 의미하는 Enum인 `ExceptionType`을 추가하고, 이를 이용해 생성되는 예외인 `CafegoryException`을 추가했습니다.
        - 새로운 예외 상황이 필요할 경우 `ExceptionType`에 정의하면 됩니다.
    - `CafegoryException` 이 발생할 경우 이를 처리하는 핸들러인 `CafegoryExceptionHandler`를 추가했습니다.
2. 테스트 코드 변경
    - 예외 추가로 인해 테스트 코드가 수정되었습니다.
 
# 추가 변경 필요 사항

카페 조회 등 @donghyun0304 동현님이 작업하신 부분의 예외 처리 작업이 필요합니다. 기존에 예외가 발생하는 부분을 말씀해 주시면 추가 작업 하겠습니다.
