### PR TITLE
Feature 47

### DIFF
--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -1,11 +1,14 @@
 package com.example.demo.controller;
 
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,12 +16,16 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.demo.domain.Attendance;
 import com.example.demo.domain.auth.CafegoryTokenManager;
 import com.example.demo.dto.PagedResponse;
+import com.example.demo.dto.StudyMemberStateRequest;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceJoinResult;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
+import com.example.demo.dto.UpdateAttendanceRequest;
+import com.example.demo.dto.UpdateAttendanceResponse;
 import com.example.demo.service.StudyOnceService;
 
 import lombok.RequiredArgsConstructor;
@@ -68,4 +75,22 @@ public class StudyOnceController {
 		studyOnceService.tryQuit(identityId, studyId);
 		return ResponseEntity.ok(new StudyOnceJoinResult(requestTime, true));
 	}
+
+	@PatchMapping("/{studyId:[0-9]+}/attendance")
+	public ResponseEntity<UpdateAttendanceResponse> takeAttendance(@PathVariable Long studyId,
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody UpdateAttendanceRequest request) {
+		long identityId = cafegoryTokenManager.getIdentityId(authorization);
+		Map<Long, Attendance> memberAttendances = request.getStates().stream()
+			.collect(Collectors.toMap(
+				StudyMemberStateRequest::getUserId,
+				(req) -> req.isAttendance() ? Attendance.YES : Attendance.NO
+			));
+
+		UpdateAttendanceResponse response = studyOnceService.updateAttendances(identityId, studyId,
+			memberAttendances, LocalDateTime.now());
+		return ResponseEntity.ok(response);
+
+	}
+
 }

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -1,8 +1,6 @@
 package com.example.demo.controller;
 
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,10 +14,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.example.demo.domain.Attendance;
 import com.example.demo.domain.auth.CafegoryTokenManager;
 import com.example.demo.dto.PagedResponse;
-import com.example.demo.dto.StudyMemberStateRequest;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceJoinResult;
 import com.example.demo.dto.StudyOnceSearchRequest;
@@ -80,17 +76,10 @@ public class StudyOnceController {
 	public ResponseEntity<UpdateAttendanceResponse> takeAttendance(@PathVariable Long studyId,
 		@RequestHeader("Authorization") String authorization,
 		@RequestBody UpdateAttendanceRequest request) {
-		long identityId = cafegoryTokenManager.getIdentityId(authorization);
-		Map<Long, Attendance> memberAttendances = request.getStates().stream()
-			.collect(Collectors.toMap(
-				StudyMemberStateRequest::getUserId,
-				(req) -> req.isAttendance() ? Attendance.YES : Attendance.NO
-			));
-
-		UpdateAttendanceResponse response = studyOnceService.updateAttendances(identityId, studyId,
-			memberAttendances, LocalDateTime.now());
+		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
+		UpdateAttendanceResponse response = studyOnceService.updateAttendances(leaderId, studyId,
+			request, LocalDateTime.now());
 		return ResponseEntity.ok(response);
-
 	}
 
 }

--- a/src/main/java/com/example/demo/domain/Attendance.java
+++ b/src/main/java/com/example/demo/domain/Attendance.java
@@ -1,5 +1,15 @@
 package com.example.demo.domain;
 
 public enum Attendance {
-	YES, NO;
+	YES(true), NO(false);
+
+	private final boolean isPresent;
+
+	Attendance(boolean isPresent) {
+		this.isPresent = isPresent;
+	}
+
+	public boolean isPresent() {
+		return isPresent;
+	}
 }

--- a/src/main/java/com/example/demo/domain/BaseEntity.java
+++ b/src/main/java/com/example/demo/domain/BaseEntity.java
@@ -1,0 +1,17 @@
+package com.example.demo.domain;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.MappedSuperclass;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@MappedSuperclass
+public class BaseEntity {
+
+	private LocalDateTime createdDate;
+	private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/example/demo/domain/StudyMember.java
+++ b/src/main/java/com/example/demo/domain/StudyMember.java
@@ -15,6 +15,7 @@ import javax.persistence.MapsId;
 import javax.persistence.Table;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -39,6 +40,7 @@ public class StudyMember {
 	@Setter
 	private Attendance attendance;
 
+	@Builder
 	public StudyMember(MemberImpl member, StudyOnceImpl study) {
 		this.member = member;
 		this.study = study;

--- a/src/main/java/com/example/demo/domain/StudyMember.java
+++ b/src/main/java/com/example/demo/domain/StudyMember.java
@@ -54,4 +54,5 @@ public class StudyMember {
 		return (start.isBefore(studyEndDateTime) || start.isEqual(studyEndDateTime)) && (studyStartDateTime.isBefore(
 			end) || studyStartDateTime.isEqual(end));
 	}
+
 }

--- a/src/main/java/com/example/demo/domain/StudyMember.java
+++ b/src/main/java/com/example/demo/domain/StudyMember.java
@@ -24,7 +24,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "study_member")
-public class StudyMember {
+public class StudyMember extends BaseEntity {
 	@EmbeddedId
 	private StudyMemberId id;
 

--- a/src/main/java/com/example/demo/dto/StudyMemberStateRequest.java
+++ b/src/main/java/com/example/demo/dto/StudyMemberStateRequest.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class StudyMemberStateRequest {
+
+	private Long userId;
+	private boolean attendance;
+	private LocalDateTime lastUpdateTime;
+
+	public StudyMemberStateRequest() {
+	}
+
+	public StudyMemberStateRequest(Long userId, boolean attendance, LocalDateTime lastUpdateTime) {
+		this.userId = userId;
+		this.attendance = attendance;
+		this.lastUpdateTime = lastUpdateTime;
+	}
+}

--- a/src/main/java/com/example/demo/dto/StudyMemberStateResponse.java
+++ b/src/main/java/com/example/demo/dto/StudyMemberStateResponse.java
@@ -1,0 +1,16 @@
+package com.example.demo.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class StudyMemberStateResponse {
+
+	private final Long userId;
+	private final boolean attendance;
+	private final LocalDateTime lastUpdateTime;
+
+}

--- a/src/main/java/com/example/demo/dto/StudyOnceCreateRequest.java
+++ b/src/main/java/com/example/demo/dto/StudyOnceCreateRequest.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class StudyOnceCreateRequest {
 	private long cafeId;
 	private String name;

--- a/src/main/java/com/example/demo/dto/UpdateAttendanceRequest.java
+++ b/src/main/java/com/example/demo/dto/UpdateAttendanceRequest.java
@@ -1,0 +1,18 @@
+package com.example.demo.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateAttendanceRequest {
+
+	private List<StudyMemberStateRequest> states;
+
+	public UpdateAttendanceRequest() {
+	}
+
+	public UpdateAttendanceRequest(List<StudyMemberStateRequest> states) {
+		this.states = states;
+	}
+}

--- a/src/main/java/com/example/demo/dto/UpdateAttendanceResponse.java
+++ b/src/main/java/com/example/demo/dto/UpdateAttendanceResponse.java
@@ -1,4 +1,14 @@
 package com.example.demo.dto;
 
-public class UpdateAttendanceResponse { //ToDo 구현 필요
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateAttendanceResponse {
+
+	private final List<StudyMemberStateResponse> states;
+
 }

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -28,6 +28,7 @@ public enum ExceptionType {
 	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
 	STUDY_ONCE_INVALID_LEADER(BAD_REQUEST, "스터디 리더가 아닙니다."),
 	STUDY_ONCE_EARLY_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 시작 10분 이후여야 합니다."),
+	STUDY_ONCE_LATE_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 진행시간 절반이 지나기전에만 변경할 수 있습니다. "),
 	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다."),
 	REVIEW_NOT_FOUND(NOT_FOUND, "없는 리뷰입니다."),
 	REVIEW_OVER_CONTENT_SIZE(BAD_REQUEST, "리뷰 글자수가 최대 글자수 이하여야 합니다."),

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -26,15 +26,17 @@ public enum ExceptionType {
 	STUDY_ONCE_TOO_LATE_QUIT(CONFLICT, "카공 인원 모집이 확정된 이후 참여 취소를 할 수 없습니다."),
 	STUDY_ONCE_TRY_QUIT_NOT_JOIN(CONFLICT, "참여중인 카공이 아닙니다."),
 	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
+	STUDY_ONCE_INVALID_LEADER(BAD_REQUEST, "스터디 리더가 아닙니다."),
 	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다."),
-	CAFE_NOT_FOUND(NOT_FOUND, "없는 카페입니다."),
 	REVIEW_NOT_FOUND(NOT_FOUND, "없는 리뷰입니다."),
 	REVIEW_OVER_CONTENT_SIZE(BAD_REQUEST, "리뷰 글자수가 최대 글자수 이하여야 합니다."),
 	REVIEW_INVALID_MEMBER(FORBIDDEN, "자신이 작성한 리뷰만 수정할 수 있습니다."),
 	REVIEW_CONTENT_EMPTY_OR_WHITESPACE(BAD_REQUEST, "리뷰 내용은 null, 빈 값, 혹은 공백만으로 이루어질 수 없습니다."),
 	REVIEW_INVALID_RATE_RANGE(BAD_REQUEST, "평점이 허용된 범위를 벗어났습니다."),
+	CAFE_NOT_FOUND(NOT_FOUND, "없는 카페입니다."),
 	CAFE_INVALID_BUSINESS_TIME_RANGE(BAD_REQUEST, "영업시간이 허용된 범위를 벗어났습니다."),
-	CAFE_NOT_FOUND_DAY_OF_WEEK(INTERNAL_SERVER_ERROR, "현재 요일과 일치하는 요일을 찾을 수 없습니다.");
+	CAFE_NOT_FOUND_DAY_OF_WEEK(INTERNAL_SERVER_ERROR, "현재 요일과 일치하는 요일을 찾을 수 없습니다."),
+	STUDY_MEMBER_NOT_FOUND(NOT_FOUND, "없는 스터디멤버입니다.");
 
 	private final HttpStatus errStatus;
 	private final String errorMessage;

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -27,6 +27,7 @@ public enum ExceptionType {
 	STUDY_ONCE_TRY_QUIT_NOT_JOIN(CONFLICT, "참여중인 카공이 아닙니다."),
 	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
 	STUDY_ONCE_INVALID_LEADER(BAD_REQUEST, "스터디 리더가 아닙니다."),
+	STUDY_ONCE_EARLY_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 시작 10분 이후여야 합니다."),
 	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다."),
 	REVIEW_NOT_FOUND(NOT_FOUND, "없는 리뷰입니다."),
 	REVIEW_OVER_CONTENT_SIZE(BAD_REQUEST, "리뷰 글자수가 최대 글자수 이하여야 합니다."),

--- a/src/main/java/com/example/demo/repository/StudyOnceRepository.java
+++ b/src/main/java/com/example/demo/repository/StudyOnceRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.demo.domain.StudyOnceImpl;
 
 public interface StudyOnceRepository extends JpaRepository<StudyOnceImpl, Long>, StudyOnceRepositoryCustom {
+
+	boolean existsByLeaderId(Long leaderId);
 }

--- a/src/main/java/com/example/demo/service/CafeQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/CafeQueryServiceImpl.java
@@ -74,7 +74,7 @@ public class CafeQueryServiceImpl implements CafeQueryService {
 		}
 		return produceCafeResponse(findCafe);
 	}
-
+ 	
 	@Override
 	public CafeResponse searchCafeForNotMemberByCafeId(Long cafeId) {
 		CafeImpl findCafe = findCafeById(cafeId);

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -1,13 +1,13 @@
 package com.example.demo.service;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 import com.example.demo.domain.Attendance;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
+import com.example.demo.dto.UpdateAttendanceRequest;
 import com.example.demo.dto.UpdateAttendanceResponse;
 
 public interface StudyOnceService {
@@ -20,7 +20,7 @@ public interface StudyOnceService {
 	StudyOnceSearchResponse searchByStudyId(long studyId);
 
 	UpdateAttendanceResponse updateAttendances(long leaderId, long studyOnceId,
-		Map<Long, Attendance> memberAttendances, LocalDateTime now);
+		UpdateAttendanceRequest request, LocalDateTime now);
 
 	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, LocalDateTime now);
 

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -21,7 +21,7 @@ public interface StudyOnceService {
 	List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
 		boolean attendance);
 
-	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, );
+	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance);
 
 	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -22,8 +22,7 @@ public interface StudyOnceService {
 	List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
 		boolean attendance);
 
-	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance,
-		LocalDateTime studyStartDateTime, LocalDateTime now);
+	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, LocalDateTime now);
 
 	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -2,6 +2,7 @@ package com.example.demo.service;
 
 import java.util.List;
 
+import com.example.demo.domain.Attendance;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
@@ -17,7 +18,10 @@ public interface StudyOnceService {
 
 	StudyOnceSearchResponse searchByStudyId(long studyId);
 
-	List<UpdateAttendanceResponse> updateAttendance(long leaderId, long memberId, boolean attendance);
+	List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
+		boolean attendance);
+
+	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, );
 
 	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.demo.domain.Attendance;
@@ -21,7 +22,8 @@ public interface StudyOnceService {
 	List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
 		boolean attendance);
 
-	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance);
+	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance,
+		LocalDateTime studyStartDateTime, LocalDateTime now);
 
 	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -1,7 +1,7 @@
 package com.example.demo.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Map;
 
 import com.example.demo.domain.Attendance;
 import com.example.demo.dto.PagedResponse;
@@ -19,8 +19,8 @@ public interface StudyOnceService {
 
 	StudyOnceSearchResponse searchByStudyId(long studyId);
 
-	List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
-		boolean attendance);
+	UpdateAttendanceResponse updateAttendances(long leaderId, long studyOnceId,
+		Map<Long, Attendance> memberAttendances, LocalDateTime now);
 
 	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, LocalDateTime now);
 

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.service;
 
 import static com.example.demo.exception.ExceptionType.*;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -107,10 +108,17 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		if (!studyOnceRepository.existsByLeaderId(leaderId)) {
 			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
 		}
-		
+
 		StudyOnceImpl searched = findStudyOnceById(studyOnceId);
-		if (now.minusMinutes(10).isBefore(searched.getStartDateTime())) {
+		LocalDateTime startDateTime = searched.getStartDateTime();
+		LocalDateTime endDateTime = searched.getEndDateTime();
+		if (now.minusMinutes(10).isBefore(startDateTime)) {
 			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
+		}
+		Duration halfDuration = Duration.between(startDateTime, endDateTime).dividedBy(2);
+		LocalDateTime midTime = startDateTime.plus(halfDuration);
+		if (now.isAfter(midTime)) {
+			throw new CafegoryException(STUDY_ONCE_LATE_TAKE_ATTENDANCE);
 		}
 
 		StudyMember findStudyMember = studyMemberRepository.findById(new StudyMemberId(memberId, studyOnceId))

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -5,6 +5,7 @@ import static com.example.demo.exception.ExceptionType.*;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import com.example.demo.domain.StudyMember;
 import com.example.demo.domain.StudyMemberId;
 import com.example.demo.domain.StudyOnceImpl;
 import com.example.demo.dto.PagedResponse;
+import com.example.demo.dto.StudyMemberStateResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
@@ -97,9 +99,18 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
-		boolean attendance) {
-		return null;
+	public UpdateAttendanceResponse updateAttendances(long leaderId, long studyOnceId,
+		Map<Long, Attendance> memberAttendances, LocalDateTime now) {
+		for (Map.Entry<Long, Attendance> entry : memberAttendances.entrySet()) {
+			updateAttendance(leaderId, studyOnceId, entry.getKey(), entry.getValue(), now);
+		}
+		List<StudyMemberId> studyMemberIds = memberAttendances.keySet().stream()
+			.map(memberId -> new StudyMemberId(memberId, studyOnceId))
+			.collect(Collectors.toList());
+		return new UpdateAttendanceResponse(studyMemberRepository.findAllById(studyMemberIds).stream()
+			.map(studyMember -> new StudyMemberStateResponse(studyMember.getId().getMemberId(),
+				studyMember.getAttendance().isPresent(), LocalDateTime.of(2999, 12, 31, 12, 0)))
+			.collect(Collectors.toList()));
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -9,9 +9,11 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.demo.domain.Attendance;
 import com.example.demo.domain.CafeImpl;
 import com.example.demo.domain.MemberImpl;
 import com.example.demo.domain.StudyMember;
+import com.example.demo.domain.StudyMemberId;
 import com.example.demo.domain.StudyOnceImpl;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
@@ -94,8 +96,19 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public List<UpdateAttendanceResponse> updateAttendance(long leaderId, long memberId, boolean attendance) {
+	public List<UpdateAttendanceResponse> updateAttendances(long leaderId, long studyOnceId, long studyMemberId,
+		boolean attendance) {
 		return null;
+	}
+
+	@Override
+	public void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance) {
+		if (!studyOnceRepository.existsByLeaderId(leaderId)) {
+			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
+		}
+		StudyMember findStudyMember = studyMemberRepository.findById(new StudyMemberId(memberId, studyOnceId))
+			.orElseThrow(() -> new CafegoryException(STUDY_MEMBER_NOT_FOUND));
+		findStudyMember.setAttendance(attendance);
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -110,20 +110,28 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		}
 
 		StudyOnceImpl searched = findStudyOnceById(studyOnceId);
-		LocalDateTime startDateTime = searched.getStartDateTime();
-		LocalDateTime endDateTime = searched.getEndDateTime();
-		if (now.minusMinutes(10).isBefore(startDateTime)) {
-			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
-		}
-		Duration halfDuration = Duration.between(startDateTime, endDateTime).dividedBy(2);
-		LocalDateTime midTime = startDateTime.plus(halfDuration);
-		if (now.isAfter(midTime)) {
-			throw new CafegoryException(STUDY_ONCE_LATE_TAKE_ATTENDANCE);
-		}
+		validateEarlyToTakeAttendance(now, searched.getStartDateTime());
+		validateLateToTakeAttendance(now, searched.getStartDateTime(), searched.getEndDateTime());
 
 		StudyMember findStudyMember = studyMemberRepository.findById(new StudyMemberId(memberId, studyOnceId))
 			.orElseThrow(() -> new CafegoryException(STUDY_MEMBER_NOT_FOUND));
 		findStudyMember.setAttendance(attendance);
+	}
+
+	private void validateLateToTakeAttendance(LocalDateTime now, LocalDateTime startDateTime,
+		LocalDateTime endDateTime) {
+		Duration halfDuration = Duration.between(startDateTime, endDateTime).dividedBy(2);
+		LocalDateTime midTime = startDateTime.plus(halfDuration);
+
+		if (now.isAfter(midTime)) {
+			throw new CafegoryException(STUDY_ONCE_LATE_TAKE_ATTENDANCE);
+		}
+	}
+
+	private void validateEarlyToTakeAttendance(LocalDateTime now, LocalDateTime startDateTime) {
+		if (now.minusMinutes(10).isBefore(startDateTime)) {
+			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
+		}
 	}
 
 	private StudyOnceImpl findStudyOnceById(long studyOnceId) {

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -104,15 +104,22 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	@Override
 	public void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance,
 		LocalDateTime studyStartDateTime, LocalDateTime now) {
-		if (now.minusMinutes(10).isBefore(studyStartDateTime)) {
+		StudyOnceImpl searched = findStudyOnceById(studyOnceId);
+		if (now.minusMinutes(10).isBefore(searched.getStartDateTime())) {
 			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
 		}
 		if (!studyOnceRepository.existsByLeaderId(leaderId)) {
 			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
 		}
+		
 		StudyMember findStudyMember = studyMemberRepository.findById(new StudyMemberId(memberId, studyOnceId))
 			.orElseThrow(() -> new CafegoryException(STUDY_MEMBER_NOT_FOUND));
 		findStudyMember.setAttendance(attendance);
+	}
+
+	private StudyOnceImpl findStudyOnceById(long studyOnceId) {
+		return studyOnceRepository.findById(studyOnceId)
+			.orElseThrow(() -> new CafegoryException(STUDY_ONCE_NOT_FOUND));
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -102,7 +102,11 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance) {
+	public void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance,
+		LocalDateTime studyStartDateTime, LocalDateTime now) {
+		if (now.minusMinutes(10).isBefore(studyStartDateTime)) {
+			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
+		}
 		if (!studyOnceRepository.existsByLeaderId(leaderId)) {
 			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
 		}

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -112,7 +112,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	private List<StudyMemberStateResponse> mapToStateResponses(List<StudyMember> studyMembers) {
 		return studyMembers.stream()
 			.map(studyMember -> new StudyMemberStateResponse(studyMember.getId().getMemberId(),
-				studyMember.getAttendance().isPresent(), LocalDateTime.of(2999, 12, 31, 12, 0)))
+				studyMember.getAttendance().isPresent(), studyMember.getLastModifiedDate()))
 			.collect(Collectors.toList());
 	}
 
@@ -144,6 +144,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		StudyMember findStudyMember = studyMemberRepository.findById(new StudyMemberId(memberId, studyOnceId))
 			.orElseThrow(() -> new CafegoryException(STUDY_MEMBER_NOT_FOUND));
 		findStudyMember.setAttendance(attendance);
+		findStudyMember.setLastModifiedDate(now);
 	}
 
 	private void validateLateToTakeAttendance(LocalDateTime now, LocalDateTime startDateTime,

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -103,15 +103,16 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 
 	@Override
 	public void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance,
-		LocalDateTime studyStartDateTime, LocalDateTime now) {
-		StudyOnceImpl searched = findStudyOnceById(studyOnceId);
-		if (now.minusMinutes(10).isBefore(searched.getStartDateTime())) {
-			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
-		}
+		LocalDateTime now) {
 		if (!studyOnceRepository.existsByLeaderId(leaderId)) {
 			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
 		}
 		
+		StudyOnceImpl searched = findStudyOnceById(studyOnceId);
+		if (now.minusMinutes(10).isBefore(searched.getStartDateTime())) {
+			throw new CafegoryException(STUDY_ONCE_EARLY_TAKE_ATTENDANCE);
+		}
+
 		StudyMember findStudyMember = studyMemberRepository.findById(new StudyMemberId(memberId, studyOnceId))
 			.orElseThrow(() -> new CafegoryException(STUDY_MEMBER_NOT_FOUND));
 		findStudyMember.setAttendance(attendance);

--- a/src/test/java/com/example/demo/builder/TestStudyMemberBuilder.java
+++ b/src/test/java/com/example/demo/builder/TestStudyMemberBuilder.java
@@ -7,15 +7,9 @@ import com.example.demo.domain.StudyOnceImpl;
 
 public class TestStudyMemberBuilder {
 
-	// private StudyMemberId id;
 	private MemberImpl member;
 	private StudyOnceImpl study;
 	private Attendance attendance = Attendance.YES;
-
-	// public TestStudyMemberBuilder id(StudyMemberId id) {
-	// 	this.id = id;
-	// 	return this;
-	// }
 
 	public TestStudyMemberBuilder member(MemberImpl member) {
 		this.member = member;

--- a/src/test/java/com/example/demo/builder/TestStudyMemberBuilder.java
+++ b/src/test/java/com/example/demo/builder/TestStudyMemberBuilder.java
@@ -1,0 +1,41 @@
+package com.example.demo.builder;
+
+import com.example.demo.domain.Attendance;
+import com.example.demo.domain.MemberImpl;
+import com.example.demo.domain.StudyMember;
+import com.example.demo.domain.StudyOnceImpl;
+
+public class TestStudyMemberBuilder {
+
+	// private StudyMemberId id;
+	private MemberImpl member;
+	private StudyOnceImpl study;
+	private Attendance attendance = Attendance.YES;
+
+	// public TestStudyMemberBuilder id(StudyMemberId id) {
+	// 	this.id = id;
+	// 	return this;
+	// }
+
+	public TestStudyMemberBuilder member(MemberImpl member) {
+		this.member = member;
+		return this;
+	}
+
+	public TestStudyMemberBuilder study(StudyOnceImpl study) {
+		this.study = study;
+		return this;
+	}
+
+	public TestStudyMemberBuilder attendanceYes() {
+		this.attendance = Attendance.YES;
+		return this;
+	}
+
+	public StudyMember build(MemberImpl member, StudyOnceImpl study) {
+		return StudyMember.builder()
+			.member(member)
+			.study(study)
+			.build();
+	}
+}

--- a/src/test/java/com/example/demo/builder/TestStudyOnceBuilder.java
+++ b/src/test/java/com/example/demo/builder/TestStudyOnceBuilder.java
@@ -1,0 +1,87 @@
+package com.example.demo.builder;
+
+import java.time.LocalDateTime;
+
+import com.example.demo.domain.CafeImpl;
+import com.example.demo.domain.MemberImpl;
+import com.example.demo.domain.StudyOnceImpl;
+
+public class TestStudyOnceBuilder {
+
+	private Long id;
+	private String name = "카페 스터디";
+	private CafeImpl cafe;
+	private LocalDateTime startDateTime = LocalDateTime.of(2999, 2, 16, 12, 0);
+	private LocalDateTime endDateTime = LocalDateTime.of(2999, 2, 16, 15, 0);
+	private int maxMemberCount = 5;
+	private int nowMemberCount = 0;
+	private boolean isEnd = false;
+	private boolean ableToTalk = true;
+	private MemberImpl leader;
+
+	public TestStudyOnceBuilder id(Long id) {
+		this.id = id;
+		return this;
+	}
+
+	public TestStudyOnceBuilder name(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public TestStudyOnceBuilder cafe(CafeImpl cafe) {
+		this.cafe = cafe;
+		return this;
+	}
+
+	public TestStudyOnceBuilder startDateTime(LocalDateTime startDateTime) {
+		this.startDateTime = startDateTime;
+		return this;
+	}
+
+	public TestStudyOnceBuilder endDateTime(LocalDateTime endDateTime) {
+		this.endDateTime = endDateTime;
+		return this;
+	}
+
+	public TestStudyOnceBuilder maxMemberCount(int maxMemberCount) {
+		this.maxMemberCount = maxMemberCount;
+		return this;
+	}
+
+	public TestStudyOnceBuilder nowMemberCount(int nowMemberCount) {
+		this.nowMemberCount = nowMemberCount;
+		return this;
+	}
+
+	public TestStudyOnceBuilder end() {
+		this.isEnd = true;
+		return this;
+	}
+
+	public TestStudyOnceBuilder talkImpossible() {
+		this.ableToTalk = false;
+		return this;
+	}
+
+	public TestStudyOnceBuilder leader(MemberImpl leader) {
+		this.leader = leader;
+		return this;
+	}
+
+	public StudyOnceImpl build() {
+		StudyOnceImpl studyOnce = StudyOnceImpl.builder()
+			.id(id)
+			.name(name)
+			.cafe(cafe)
+			.startDateTime(startDateTime)
+			.endDateTime(endDateTime)
+			.maxMemberCount(maxMemberCount)
+			.nowMemberCount(nowMemberCount)
+			.isEnd(isEnd)
+			.ableToTalk(ableToTalk)
+			.leader(leader)
+			.build();
+		return studyOnce;
+	}
+}

--- a/src/test/java/com/example/demo/config/TestConfig.java
+++ b/src/test/java/com/example/demo/config/TestConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Bean;
 import com.example.demo.helper.CafePersistHelper;
 import com.example.demo.helper.MemberPersistHelper;
 import com.example.demo.helper.ReviewPersistHelper;
+import com.example.demo.helper.StudyMemberPersistHelper;
+import com.example.demo.helper.StudyOncePersistHelper;
 import com.example.demo.helper.ThumbnailImagePersistHelper;
 
 @TestConfiguration
@@ -29,5 +31,15 @@ public class TestConfig {
 	@Bean
 	public ReviewPersistHelper reviewPersistHelper() {
 		return new ReviewPersistHelper();
+	}
+
+	@Bean
+	public StudyMemberPersistHelper studyMemberPersistHelper() {
+		return new StudyMemberPersistHelper();
+	}
+
+	@Bean
+	public StudyOncePersistHelper studyOncePersistHelper() {
+		return new StudyOncePersistHelper();
 	}
 }

--- a/src/test/java/com/example/demo/helper/MemberPersistHelper.java
+++ b/src/test/java/com/example/demo/helper/MemberPersistHelper.java
@@ -17,4 +17,10 @@ public class MemberPersistHelper {
 		em.persist(member);
 		return member;
 	}
+
+	public MemberImpl persistMemberWithName(ThumbnailImage thumbnailImage, String name) {
+		MemberImpl member = new TestMemberBuilder().name(name).thumbnailImage(thumbnailImage).build();
+		em.persist(member);
+		return member;
+	}
 }

--- a/src/test/java/com/example/demo/helper/StudyMemberPersistHelper.java
+++ b/src/test/java/com/example/demo/helper/StudyMemberPersistHelper.java
@@ -1,0 +1,22 @@
+package com.example.demo.helper;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.example.demo.builder.TestStudyMemberBuilder;
+import com.example.demo.domain.MemberImpl;
+import com.example.demo.domain.StudyMember;
+import com.example.demo.domain.StudyOnceImpl;
+
+public class StudyMemberPersistHelper {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	public StudyMember persistDefaultStudyMember(MemberImpl member, StudyOnceImpl study) {
+		StudyMember studyMember = new TestStudyMemberBuilder().build(member, study);
+		em.persist(studyMember);
+		return studyMember;
+	}
+
+}

--- a/src/test/java/com/example/demo/helper/StudyOncePersistHelper.java
+++ b/src/test/java/com/example/demo/helper/StudyOncePersistHelper.java
@@ -1,0 +1,22 @@
+package com.example.demo.helper;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.example.demo.builder.TestStudyOnceBuilder;
+import com.example.demo.domain.CafeImpl;
+import com.example.demo.domain.MemberImpl;
+import com.example.demo.domain.StudyOnceImpl;
+
+public class StudyOncePersistHelper {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	public StudyOnceImpl persistDefaultStudyOnce(CafeImpl cafe, MemberImpl leader) {
+		StudyOnceImpl studyOnce = new TestStudyOnceBuilder().cafe(cafe).leader(leader).build();
+		em.persist(studyOnce);
+		return studyOnce;
+	}
+
+}

--- a/src/test/java/com/example/demo/helper/StudyOncePersistHelper.java
+++ b/src/test/java/com/example/demo/helper/StudyOncePersistHelper.java
@@ -1,5 +1,7 @@
 package com.example.demo.helper;
 
+import java.time.LocalDateTime;
+
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
@@ -15,6 +17,17 @@ public class StudyOncePersistHelper {
 
 	public StudyOnceImpl persistDefaultStudyOnce(CafeImpl cafe, MemberImpl leader) {
 		StudyOnceImpl studyOnce = new TestStudyOnceBuilder().cafe(cafe).leader(leader).build();
+		em.persist(studyOnce);
+		return studyOnce;
+	}
+
+	public StudyOnceImpl persistStudyOnceWithTime(CafeImpl cafe, MemberImpl leader, LocalDateTime startDateTime,
+		LocalDateTime endDateTime) {
+		StudyOnceImpl studyOnce = new TestStudyOnceBuilder().cafe(cafe)
+			.leader(leader)
+			.startDateTime(startDateTime)
+			.endDateTime(endDateTime)
+			.build();
 		em.persist(studyOnce);
 		return studyOnce;
 	}

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -372,7 +372,7 @@ class StudyOnceServiceImplTest {
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//when
 		studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
-			LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10));
+			LocalDateTime.of(2999, 2, 17, 18, 10));
 		em.flush();
 		em.clear();
 		StudyMember findMember = studyMemberRepository.findById(
@@ -395,13 +395,13 @@ class StudyOnceServiceImplTest {
 		//then
 		assertThatThrownBy(() ->
 			studyOnceService.updateAttendance(leader.getId(), 10L, member.getId(), Attendance.NO,
-				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
+				LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_NOT_FOUND.getErrorMessage());
 	}
 
 	@Test
-	@DisplayName("참석여부를 업데이트 할때, memberId 또는 studyId가 틀리다면 예외가 터진다.")
+	@DisplayName("참석여부를 업데이트 할때, memberId가 틀리다면 예외가 터진다.")
 	void take_attendance_memberId_exception() {
 		//given
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
@@ -413,7 +413,7 @@ class StudyOnceServiceImplTest {
 		//then
 		assertThatThrownBy(() ->
 			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), 10L, Attendance.NO,
-				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
+				LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_MEMBER_NOT_FOUND.getErrorMessage());
 	}
@@ -431,7 +431,7 @@ class StudyOnceServiceImplTest {
 		//then
 		assertThatThrownBy(() ->
 			studyOnceService.updateAttendance(10L, studyOnce.getId(), member.getId(), Attendance.NO,
-				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
+				LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_INVALID_LEADER.getErrorMessage());
 	}
@@ -443,12 +443,14 @@ class StudyOnceServiceImplTest {
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
 		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
 		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
-		StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		StudyOnceImpl studyOnce = studyOncePersistHelper.persistStudyOnceWithTime(cafe, leader,
+			LocalDateTime.of(2999, 2, 17, 18, 0),
+			LocalDateTime.of(2999, 2, 17, 21, 0));
 		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//then
 		studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
-			LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10));
+			LocalDateTime.of(2999, 2, 17, 18, 10));
 		em.flush();
 		em.clear();
 		StudyMember findMember = studyMemberRepository.findById(
@@ -465,7 +467,6 @@ class StudyOnceServiceImplTest {
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
 		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
 		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
-		// StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
 		StudyOnceImpl studyOnce = studyOncePersistHelper.persistStudyOnceWithTime(cafe, leader,
 			LocalDateTime.of(2999, 2, 17, 18, 0),
 			LocalDateTime.of(2999, 2, 17, 21, 0));
@@ -475,7 +476,7 @@ class StudyOnceServiceImplTest {
 		//then
 		assertThatThrownBy(() ->
 			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
-				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 9, 59, 999_999_999))
+				LocalDateTime.of(2999, 2, 17, 18, 9, 59, 999_999_999))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_EARLY_TAKE_ATTENDANCE.getErrorMessage());
 	}

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -401,7 +401,7 @@ class StudyOnceServiceImplTest {
 	}
 
 	@Test
-	@DisplayName("참석여부를 업데이트 할때, memberId가 틀리다면 예외가 터진다.")
+	@DisplayName("참석여부를 업데이트 할때, memberId 또는 studyId가 틀리다면 예외가 터진다.")
 	void take_attendance_memberId_exception() {
 		//given
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
@@ -465,7 +465,11 @@ class StudyOnceServiceImplTest {
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
 		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
 		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
-		StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		// StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		StudyOnceImpl studyOnce = studyOncePersistHelper.persistStudyOnceWithTime(cafe, leader,
+			LocalDateTime.of(2999, 2, 17, 18, 0),
+			LocalDateTime.of(2999, 2, 17, 21, 0));
+
 		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//then

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -390,7 +390,6 @@ class StudyOnceServiceImplTest {
 			LocalDateTime startDateTime
 			LocalDateTime endDateTime
 			LocalDateTime now
-			Attendance expected
 			*/
 			Arguments.of(
 				LocalDateTime.of(2999, 2, 17, 18, 0),

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -383,8 +383,8 @@ class StudyOnceServiceImplTest {
 	}
 
 	@Test
-	@DisplayName("참석여부를 업데이트 할때, cafeId가 틀리다면 예외가 터진다.")
-	void take_attendance_cafeId_exception() {
+	@DisplayName("참석여부를 업데이트 할때, 스터디가 존재하지 않으면 예외가 터진다.")
+	void take_attendance_study_exception() {
 		//given
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
 		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
@@ -397,7 +397,7 @@ class StudyOnceServiceImplTest {
 			studyOnceService.updateAttendance(leader.getId(), 10L, member.getId(), Attendance.NO,
 				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
-			.hasMessage(STUDY_MEMBER_NOT_FOUND.getErrorMessage());
+			.hasMessage(STUDY_ONCE_NOT_FOUND.getErrorMessage());
 	}
 
 	@Test
@@ -475,5 +475,21 @@ class StudyOnceServiceImplTest {
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_EARLY_TAKE_ATTENDANCE.getErrorMessage());
 	}
+
+	// @Test
+	// @DisplayName("출석 체크는 스터디 진행시간이 절반이 지나기전에만 변경할 수 있다.")
+	// void can_take_attendance_until_half_whole_study_time() {
+	// 	//given
+	// 	ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
+	// 	MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
+	// 	CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
+	// 	StudyOnceImpl studyOnce = studyOncePersistHelper.persistStudyOnceWithTime(cafe, leader, LocalDateTime.of());
+	// 	MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
+	// 	studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
+	// 	//then
+	// 	studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
+	// 		LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10));
+	//
+	// }
 
 }

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -371,7 +371,8 @@ class StudyOnceServiceImplTest {
 		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//when
-		studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO);
+		studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
+			LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10));
 		em.flush();
 		em.clear();
 		StudyMember findMember = studyMemberRepository.findById(
@@ -393,7 +394,8 @@ class StudyOnceServiceImplTest {
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//then
 		assertThatThrownBy(() ->
-			studyOnceService.updateAttendance(leader.getId(), 10L, member.getId(), Attendance.NO)
+			studyOnceService.updateAttendance(leader.getId(), 10L, member.getId(), Attendance.NO,
+				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_MEMBER_NOT_FOUND.getErrorMessage());
 	}
@@ -410,7 +412,8 @@ class StudyOnceServiceImplTest {
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//then
 		assertThatThrownBy(() ->
-			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), 10L, Attendance.NO)
+			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), 10L, Attendance.NO,
+				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_MEMBER_NOT_FOUND.getErrorMessage());
 	}
@@ -427,32 +430,50 @@ class StudyOnceServiceImplTest {
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//then
 		assertThatThrownBy(() ->
-			studyOnceService.updateAttendance(10L, studyOnce.getId(), member.getId(), Attendance.NO)
+			studyOnceService.updateAttendance(10L, studyOnce.getId(), member.getId(), Attendance.NO,
+				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_INVALID_LEADER.getErrorMessage());
 	}
 
-	// @Test
-	// @DisplayName("카공이 시작된지 10분뒤 출석 상태를 할 수 있다.")
-	// void can_take_attendance_from_start_time_in_10min() {
-	// 	//given
-	// 	ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
-	// 	MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
-	// 	CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
-	// 	StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
-	// 	MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
-	// 	studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
-	// 	//then
-	// 	studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
-	// 		LocalDateTime startDateTime, LocalDateTime now);
-	// 	em.flush();
-	// 	em.clear();
-	// 	StudyMember findMember = studyMemberRepository.findById(
-	// 		new StudyMemberId(member.getId(), studyOnce.getId())
-	// 	).get();
-	// 	//then
-	// 	assertThat(findMember.getAttendance()).isEqualTo(Attendance.NO);
-	//
-	// }
+	@Test
+	@DisplayName("카공이 시작된지 10분뒤 출석 체크를 할 수 있다.")
+	void can_take_attendance_from_start_time_in_10min() {
+		//given
+		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
+		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
+		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
+		StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
+		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
+		//then
+		studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
+			LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 10));
+		em.flush();
+		em.clear();
+		StudyMember findMember = studyMemberRepository.findById(
+			new StudyMemberId(member.getId(), studyOnce.getId())
+		).get();
+		//then
+		assertThat(findMember.getAttendance()).isEqualTo(Attendance.NO);
+	}
+
+	@Test
+	@DisplayName("카공이 시작된지 10분전이라면 예외가 터진다.")
+	void can_take_attendance_from_start_time_in_10min_exception() {
+		//given
+		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
+		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
+		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
+		StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
+		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
+		//then
+		assertThatThrownBy(() ->
+			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
+				LocalDateTime.of(2999, 2, 17, 18, 0), LocalDateTime.of(2999, 2, 17, 18, 9, 59, 999_999_999))
+		).isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_EARLY_TAKE_ATTENDANCE.getErrorMessage());
+	}
 
 }

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -359,22 +359,22 @@ class StudyOnceServiceImplTest {
 			.hasMessage(STUDY_ONCE_LEADER_QUIT_FAIL.getErrorMessage());
 	}
 
-	@Test
+	@ParameterizedTest
+	@MethodSource("provideDateTime1")
 	@DisplayName("결석 업데이트")
-	void take_attendance() {
+	void take_attendance(LocalDateTime startDateTime, LocalDateTime endDateTime, LocalDateTime now) {
 		//given
 		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
 		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "김동현");
 		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
 		StudyOnceImpl studyOnce = studyOncePersistHelper.persistStudyOnceWithTime(cafe, leader,
-			LocalDateTime.of(2999, 2, 17, 18, 0),
-			LocalDateTime.of(2999, 2, 17, 21, 0));
+			startDateTime, endDateTime);
 
 		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//when
 		studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), member.getId(), Attendance.NO,
-			LocalDateTime.of(2999, 2, 17, 18, 10));
+			now);
 		em.flush();
 		em.clear();
 		StudyMember findMember = studyMemberRepository.findById(
@@ -382,6 +382,32 @@ class StudyOnceServiceImplTest {
 		).get();
 		//then
 		assertThat(findMember.getAttendance()).isEqualTo(Attendance.NO);
+	}
+
+	private static Stream<Arguments> provideDateTime1() {
+		return Stream.of(
+			/*
+			LocalDateTime startDateTime
+			LocalDateTime endDateTime
+			LocalDateTime now
+			Attendance expected
+			*/
+			Arguments.of(
+				LocalDateTime.of(2999, 2, 17, 18, 0),
+				LocalDateTime.of(2999, 2, 17, 21, 0),
+				LocalDateTime.of(2999, 2, 17, 18, 10)
+			),
+			Arguments.of(
+				LocalDateTime.of(2999, 2, 17, 22, 0),
+				LocalDateTime.of(2999, 2, 18, 3, 0),
+				LocalDateTime.of(2999, 2, 17, 23, 59, 59, 999_999_999)
+			),
+			Arguments.of(
+				LocalDateTime.of(2999, 2, 17, 22, 0),
+				LocalDateTime.of(2999, 2, 18, 3, 0),
+				LocalDateTime.of(2999, 2, 18, 0, 0)
+			)
+		);
 	}
 
 	@Test
@@ -494,7 +520,8 @@ class StudyOnceServiceImplTest {
 		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
 		StudyOnceImpl studyOnce = studyOncePersistHelper.persistStudyOnceWithTime(cafe, leader,
 			LocalDateTime.of(2999, 2, 17, 18, 0),
-			LocalDateTime.of(2999, 2, 17, 21, 0));
+			LocalDateTime.of(2999, 2, 17, 21, 0)
+		);
 		MemberImpl member = memberPersistHelper.persistMemberWithName(thumb, "멤버");
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//when
@@ -529,5 +556,4 @@ class StudyOnceServiceImplTest {
 			.hasMessage(STUDY_ONCE_LATE_TAKE_ATTENDANCE.getErrorMessage());
 	}
 
-	//예외 상황 날짜가 변경될경우
 }


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항
기능구현
- [x] 카공장은 카공 출석 상태를 변경 할 수 있다.
+ 카공장이 아닌 다른 스터디 멤버는 출석 상태를 변경할 수 없다.
+ 카공장은 스터디에 참여한 멤버만 출석 상태를 변경할 수 있다.
- [x] 카공이 시작된지 10분뒤 출석 상태를 할 수 있다.
- [x] 따로 결석처리를 하지 않는 한, 기본적으로 출석처리가 되어있다.
- [x] 출석상태는 스터디 진행시간이 절반이 지나기전에만  변경할 수 있다.
# ps
postman으로 출석 api를 테스트 할 수 없더라구요. 인가를 받은 리더와, 멤버가 필요한데 postman으로는 테스트가 불가했습니다.
류성현님의 인수테스트가 생각이나서 atdd 세미나(https://www.youtube.com/watch?v=ITVpmjM4mUE&t=1668s) 를 듣고
인수테스트를 해보려고 했어요 
카카오톡 인가를 받아와야하는데 인가를 받으려면 카카오톡 로그인을 해야 받을수가 있어서 실패했습니다 ㅠㅠ
세미나에서도 언급하는데 실제 환경하고 비슷하게 api테스트를 해보고 싶어 RestAssured객체를 사용해봤는데 잘 안되네요
인가를 무시하고 테스트할수있는 방법도 있는데 그래야하나 싶기도하네요 ㅋㅋㅋ 일단 좀 더 찾아보고 나중에라도 적용해보고싶네요