### PR TITLE
[BUILD SUCCESS] [BUILD SUCCESS] [BUILD FAIL] Feature 55 카공 장소 변경api, 카공 참여자 정보 조회 api

### DIFF
--- a/src/main/java/com/example/demo/config/MapperConfig.java
+++ b/src/main/java/com/example/demo/config/MapperConfig.java
@@ -7,6 +7,7 @@ import com.example.demo.mapper.BusinessHourMapper;
 import com.example.demo.mapper.CafeMapper;
 import com.example.demo.mapper.ReviewMapper;
 import com.example.demo.mapper.SnsDetailMapper;
+import com.example.demo.mapper.StudyMemberMapper;
 import com.example.demo.mapper.StudyOnceMapper;
 
 @Configuration
@@ -35,5 +36,10 @@ public class MapperConfig {
 	@Bean
 	public StudyOnceMapper studyOnceMapper() {
 		return new StudyOnceMapper();
+	}
+
+	@Bean
+	public StudyMemberMapper studyMemberMapper() {
+		return new StudyMemberMapper();
 	}
 }

--- a/src/main/java/com/example/demo/controller/ReviewController.java
+++ b/src/main/java/com/example/demo/controller/ReviewController.java
@@ -43,7 +43,6 @@ public class ReviewController {
 	public ResponseEntity<ReviewResponse> saveReview(@PathVariable Long cafeId,
 		@RequestHeader("Authorization") String authorization,
 		@RequestBody @Validated ReviewSaveRequest reviewSaveRequest) {
-
 		long memberId = cafegoryTokenManager.getIdentityId(authorization);
 		Long savedReviewId = reviewService.saveReview(memberId, cafeId, reviewSaveRequest);
 		ReviewResponse response = reviewQueryService.searchOne(savedReviewId);
@@ -54,7 +53,6 @@ public class ReviewController {
 	public ResponseEntity<ReviewResponse> updateReview(@PathVariable Long reviewId,
 		@RequestHeader("Authorization") String authorization,
 		@RequestBody @Validated ReviewUpdateRequest reviewUpdateRequest) {
-
 		long memberId = cafegoryTokenManager.getIdentityId(authorization);
 		reviewService.updateReview(memberId, reviewId, reviewUpdateRequest);
 		ReviewResponse response = reviewQueryService.searchOne(reviewId);
@@ -64,7 +62,6 @@ public class ReviewController {
 	@DeleteMapping("/cafe/review/{reviewId}")
 	public ResponseEntity<ReviewResponse> deleteReview(@PathVariable Long reviewId,
 		@RequestHeader("Authorization") String authorization) {
-
 		long memberId = cafegoryTokenManager.getIdentityId(authorization);
 		ReviewResponse response = reviewQueryService.searchOne(reviewId);
 		reviewService.deleteReview(memberId, reviewId);

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -1,5 +1,7 @@
 package com.example.demo.controller;
 
+import static com.example.demo.exception.ExceptionType.*;
+
 import java.time.LocalDateTime;
 
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,8 @@ import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
 import com.example.demo.dto.UpdateAttendanceRequest;
 import com.example.demo.dto.UpdateAttendanceResponse;
+import com.example.demo.exception.CafegoryException;
+import com.example.demo.repository.StudyOnceRepository;
 import com.example.demo.service.CafeQueryService;
 import com.example.demo.service.StudyOnceService;
 
@@ -36,6 +40,7 @@ public class StudyOnceController {
 	private final StudyOnceService studyOnceService;
 	private final CafegoryTokenManager cafegoryTokenManager;
 	private final CafeQueryService cafeQueryService;
+	private final StudyOnceRepository studyOnceRepository;
 
 	@GetMapping("/{studyOnceId:[0-9]+}")
 	public ResponseEntity<StudyOnceSearchResponse> search(@PathVariable Long studyOnceId) {
@@ -100,6 +105,9 @@ public class StudyOnceController {
 	public ResponseEntity<StudyMembersResponse> findStudyMemberList(@PathVariable Long studyOnceId,
 		@RequestHeader("Authorization") String authorization) {
 		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
+		if (!studyOnceService.isStudyOnceLeader(leaderId, studyOnceId)) {
+			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
+		}
 		StudyMembersResponse response = studyOnceService.findStudyMembersById(studyOnceId);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -106,7 +106,7 @@ public class StudyOnceController {
 		@RequestHeader("Authorization") String authorization) {
 		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
 		if (!studyOnceService.isStudyOnceLeader(leaderId, studyOnceId)) {
-			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
+			throw new CafegoryException(STUDY_ONCE_LEADER_PERMISSION_DENIED);
 		}
 		StudyMembersResponse response = studyOnceService.findStudyMembersById(studyOnceId);
 		return ResponseEntity.ok(response);

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.demo.domain.auth.CafegoryTokenManager;
+import com.example.demo.dto.CafeSearchResponse;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceJoinResult;
@@ -22,6 +23,7 @@ import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
 import com.example.demo.dto.UpdateAttendanceRequest;
 import com.example.demo.dto.UpdateAttendanceResponse;
+import com.example.demo.service.CafeQueryService;
 import com.example.demo.service.StudyOnceService;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class StudyOnceController {
 	private final StudyOnceService studyOnceService;
 	private final CafegoryTokenManager cafegoryTokenManager;
+	private final CafeQueryService cafeQueryService;
 
 	@GetMapping("/{studyOnceId:[0-9]+}")
 	public ResponseEntity<StudyOnceSearchResponse> search(@PathVariable Long studyOnceId) {
@@ -79,6 +82,16 @@ public class StudyOnceController {
 		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
 		UpdateAttendanceResponse response = studyOnceService.updateAttendances(leaderId, studyOnceId,
 			request, LocalDateTime.now());
+		return ResponseEntity.ok(response);
+	}
+
+	@PatchMapping("/{studyOnceId:[0-9]+}/location")
+	public ResponseEntity<CafeSearchResponse> changeCafe(@PathVariable Long studyOnceId,
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody Long cafeId) {
+		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
+		Long changedCafeId = studyOnceService.changeCafe(leaderId, studyOnceId, cafeId);
+		CafeSearchResponse response = cafeQueryService.searchCafeBasicInfoById(changedCafeId);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.demo.domain.auth.CafegoryTokenManager;
 import com.example.demo.dto.CafeSearchResponse;
 import com.example.demo.dto.PagedResponse;
+import com.example.demo.dto.StudyMembersResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceJoinResult;
 import com.example.demo.dto.StudyOnceSearchRequest;
@@ -92,6 +93,14 @@ public class StudyOnceController {
 		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
 		Long changedCafeId = studyOnceService.changeCafe(leaderId, studyOnceId, cafeId);
 		CafeSearchResponse response = cafeQueryService.searchCafeBasicInfoById(changedCafeId);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/{studyOnceId:[0-9]+}/member/list")
+	public ResponseEntity<StudyMembersResponse> findStudyMemberList(@PathVariable Long studyOnceId,
+		@RequestHeader("Authorization") String authorization) {
+		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
+		StudyMembersResponse response = studyOnceService.findStudyMembersById(studyOnceId);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/example/demo/domain/MemberImpl.java
+++ b/src/main/java/com/example/demo/domain/MemberImpl.java
@@ -53,4 +53,5 @@ public class MemberImpl implements Member {
 	public void addStudyMember(StudyMember studyMember) {
 		studyMembers.add(studyMember);
 	}
+
 }

--- a/src/main/java/com/example/demo/domain/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/StudyOnce.java
@@ -14,4 +14,6 @@ public interface StudyOnce {
 	StudyMember tryQuit(Member memberThatExpectedToQuit, LocalDateTime requestTime);
 
 	void updateAttendance(Member leader, Member member, boolean attendance);
+
+	void changeCafe(CafeImpl cafe);
 }

--- a/src/main/java/com/example/demo/domain/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/StudyOnce.java
@@ -16,4 +16,7 @@ public interface StudyOnce {
 	void updateAttendance(Member leader, Member member, boolean attendance);
 
 	void changeCafe(CafeImpl cafe);
+
+	boolean isLeader(MemberImpl member);
+
 }

--- a/src/main/java/com/example/demo/domain/StudyOnceImpl.java
+++ b/src/main/java/com/example/demo/domain/StudyOnceImpl.java
@@ -158,6 +158,11 @@ public class StudyOnceImpl implements StudyOnce {
 		cafe.getStudyOnceGroup().add(this);
 	}
 
+	@Override
+	public boolean isLeader(MemberImpl member) {
+		return leader.getId().equals(member.getId());
+	}
+
 	public boolean canJoin(LocalDateTime baseDateTime) {
 		Duration between = Duration.between(baseDateTime, startDateTime);
 		return between.toSeconds() >= 60 * 60;

--- a/src/main/java/com/example/demo/domain/StudyOnceImpl.java
+++ b/src/main/java/com/example/demo/domain/StudyOnceImpl.java
@@ -152,6 +152,12 @@ public class StudyOnceImpl implements StudyOnce {
 
 	}
 
+	@Override
+	public void changeCafe(CafeImpl cafe) {
+		this.cafe = cafe;
+		cafe.getStudyOnceGroup().add(this);
+	}
+
 	public boolean canJoin(LocalDateTime baseDateTime) {
 		Duration between = Duration.between(baseDateTime, startDateTime);
 		return between.toSeconds() >= 60 * 60;

--- a/src/main/java/com/example/demo/dto/MemberResponse.java
+++ b/src/main/java/com/example/demo/dto/MemberResponse.java
@@ -10,5 +10,4 @@ public class MemberResponse {
 	private final long memberId;
 	private final String name;
 	private final String thumbnailImg;
-	
 }

--- a/src/main/java/com/example/demo/dto/MemberResponse.java
+++ b/src/main/java/com/example/demo/dto/MemberResponse.java
@@ -1,0 +1,14 @@
+package com.example.demo.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberResponse {
+
+	private final long memberId;
+	private final String name;
+	private final String thumbnailImg;
+	
+}

--- a/src/main/java/com/example/demo/dto/StudyMembersResponse.java
+++ b/src/main/java/com/example/demo/dto/StudyMembersResponse.java
@@ -1,0 +1,14 @@
+package com.example.demo.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class StudyMembersResponse {
+
+	private final List<MemberResponse> joinedMembers;
+
+}

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -27,6 +27,7 @@ public enum ExceptionType {
 	STUDY_ONCE_TRY_QUIT_NOT_JOIN(CONFLICT, "참여중인 카공이 아닙니다."),
 	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
 	STUDY_ONCE_INVALID_LEADER(BAD_REQUEST, "스터디 리더가 아닙니다."),
+	STUDY_ONCE_LOCATION_CHANGE_PERMISSION_DENIED(FORBIDDEN, "스터디 리더만 장소 변경을 할 권한이 있습니다."),
 	STUDY_ONCE_EARLY_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 시작 10분 이후여야 합니다."),
 	STUDY_ONCE_LATE_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 진행시간 절반이 지나기전에만 변경할 수 있습니다. "),
 	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다."),

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -27,6 +27,7 @@ public enum ExceptionType {
 	STUDY_ONCE_TRY_QUIT_NOT_JOIN(CONFLICT, "참여중인 카공이 아닙니다."),
 	STUDY_ONCE_LEADER_QUIT_FAIL(CONFLICT, "카공장은 다른 참여자가 있는 경우 참여 취소를 할 수 없습니다."),
 	STUDY_ONCE_INVALID_LEADER(BAD_REQUEST, "스터디 리더가 아닙니다."),
+	STUDY_ONCE_LEADER_PERMISSION_DENIED(FORBIDDEN, "스터디 리더만 권한이 있습니다."),
 	STUDY_ONCE_LOCATION_CHANGE_PERMISSION_DENIED(FORBIDDEN, "스터디 리더만 장소 변경을 할 권한이 있습니다."),
 	STUDY_ONCE_EARLY_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 시작 10분 이후여야 합니다."),
 	STUDY_ONCE_LATE_TAKE_ATTENDANCE(BAD_REQUEST, "스터디 출석체크는 스터디 진행시간 절반이 지나기전에만 변경할 수 있습니다. "),

--- a/src/main/java/com/example/demo/mapper/CafeMapper.java
+++ b/src/main/java/com/example/demo/mapper/CafeMapper.java
@@ -24,25 +24,33 @@ public class CafeMapper {
 		OpenChecker<BusinessHour> openChecker) {
 		return cafes.stream()
 			.map(cafe ->
-				new CafeSearchResponse(
-					cafe.getId(),
-					cafe.getName(),
-					cafe.showFullAddress(),
-					cafe.getBusinessHours().stream()
-						.map(hour -> new BusinessHourResponse(hour.getDay(), hour.getStartTime().toString(),
-							hour.getEndTime().toString()))
-						.collect(Collectors.toList()),
-					cafe.isOpen(openChecker),
-					cafe.getSnsDetails().stream()
-						.map(s -> new SnsResponse(s.getName(), s.getUrl()))
-						.collect(Collectors.toList()),
-					cafe.getPhone(),
-					cafe.getMinBeveragePrice(),
-					cafe.getMaxAllowableStay().getValue(),
-					cafe.getAvgReviewRate()
-				)
+				produceCafeSearchResponse(cafe, openChecker)
 			)
 			.collect(Collectors.toList());
+	}
+
+	private CafeSearchResponse produceCafeSearchResponse(CafeImpl cafe, OpenChecker<BusinessHour> openChecker) {
+		return new CafeSearchResponse(
+			cafe.getId(),
+			cafe.getName(),
+			cafe.showFullAddress(),
+			cafe.getBusinessHours().stream()
+				.map(hour -> new BusinessHourResponse(hour.getDay(), hour.getStartTime().toString(),
+					hour.getEndTime().toString()))
+				.collect(Collectors.toList()),
+			cafe.isOpen(openChecker),
+			cafe.getSnsDetails().stream()
+				.map(s -> new SnsResponse(s.getName(), s.getUrl()))
+				.collect(Collectors.toList()),
+			cafe.getPhone(),
+			cafe.getMinBeveragePrice(),
+			cafe.getMaxAllowableStay().getValue(),
+			cafe.getAvgReviewRate()
+		);
+	}
+
+	public CafeSearchResponse toCafeSearchResponse(CafeImpl cafe, OpenChecker<BusinessHour> openChecker) {
+		return produceCafeSearchResponse(cafe, openChecker);
 	}
 
 	public CafeBasicInfoResponse toCafeBasicInfoResponse(CafeImpl cafe,

--- a/src/main/java/com/example/demo/mapper/StudyMemberMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyMemberMapper.java
@@ -1,5 +1,20 @@
 package com.example.demo.mapper;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.example.demo.domain.StudyMember;
+import com.example.demo.dto.MemberResponse;
+
 public class StudyMemberMapper {
+
+	public List<MemberResponse> toMemberResponses(List<StudyMember> studyMembers) {
+		return studyMembers.stream()
+			.map(studyMember -> new MemberResponse(
+				studyMember.getMember().getId(),
+				studyMember.getMember().getName(),
+				studyMember.getMember().getThumbnailImage().getThumbnailImage()))
+			.collect(Collectors.toList());
+	}
 
 }

--- a/src/main/java/com/example/demo/mapper/StudyMemberMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyMemberMapper.java
@@ -1,0 +1,5 @@
+package com.example.demo.mapper;
+
+public class StudyMemberMapper {
+
+}

--- a/src/main/java/com/example/demo/service/CafeQueryService.java
+++ b/src/main/java/com/example/demo/service/CafeQueryService.java
@@ -11,6 +11,8 @@ public interface CafeQueryService {
 
 	CafeResponse searchCafeById(Long cafeId);
 
+	CafeSearchResponse searchCafeBasicInfoById(Long cafeId);
+
 	CafeResponse searchCafeForMemberByCafeId(Long cafeId, Long memberId);
 
 	CafeResponse searchCafeForNotMemberByCafeId(Long cafeId);

--- a/src/main/java/com/example/demo/service/CafeQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/CafeQueryServiceImpl.java
@@ -70,6 +70,11 @@ public class CafeQueryServiceImpl implements CafeQueryService {
 		);
 	}
 
+	@Override
+	public CafeSearchResponse searchCafeBasicInfoById(Long cafeId) {
+		return cafeMapper.toCafeSearchResponse(findCafeById(cafeId), openChecker);
+	}
+
 	private CafeImpl findCafeById(Long cafeId) {
 		return cafeRepository.findById(cafeId)
 			.orElseThrow(() -> new CafegoryException(CAFE_NOT_FOUND));

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -30,4 +30,6 @@ public interface StudyOnceService {
 	Long changeCafe(Long requestMemberId, Long studyOnceId, Long changingCafeId);
 
 	StudyMembersResponse findStudyMembersById(Long studyOnceId);
+
+	boolean isStudyOnceLeader(Long memberId, Long studyOnceId);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -25,4 +25,6 @@ public interface StudyOnceService {
 	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, LocalDateTime now);
 
 	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
+
+	Long changeCafe(Long requestMemberId, Long studyOnceId, final Long changingCafeId);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/StudyOnceService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.example.demo.domain.Attendance;
 import com.example.demo.dto.PagedResponse;
+import com.example.demo.dto.StudyMembersResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
@@ -26,5 +27,7 @@ public interface StudyOnceService {
 
 	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
 
-	Long changeCafe(Long requestMemberId, Long studyOnceId, final Long changingCafeId);
+	Long changeCafe(Long requestMemberId, Long studyOnceId, Long changingCafeId);
+
+	StudyMembersResponse findStudyMembersById(Long studyOnceId);
 }

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -198,7 +198,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	public Long changeCafe(Long requestMemberId, Long studyOnceId, final Long changingCafeId) {
 		final StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
 		if (!isStudyOnceLeader(requestMemberId, studyOnceId)) {
-			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
+			throw new CafegoryException(STUDY_ONCE_LOCATION_CHANGE_PERMISSION_DENIED);
 		}
 		studyOnce.changeCafe(findCafeById(changingCafeId));
 		return changingCafeId;

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -27,6 +27,7 @@ import com.example.demo.dto.StudyOnceSearchResponse;
 import com.example.demo.dto.UpdateAttendanceRequest;
 import com.example.demo.dto.UpdateAttendanceResponse;
 import com.example.demo.exception.CafegoryException;
+import com.example.demo.mapper.StudyMemberMapper;
 import com.example.demo.mapper.StudyOnceMapper;
 import com.example.demo.repository.MemberRepository;
 import com.example.demo.repository.StudyMemberRepository;
@@ -45,6 +46,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	private final MemberRepository memberRepository;
 	private final StudyMemberRepository studyMemberRepository;
 	private final StudyOnceMapper studyOnceMapper;
+	private final StudyMemberMapper studyMemberMapper;
 
 	@Override
 	public void tryJoin(long memberIdThatExpectedToJoin, long studyId) {
@@ -207,12 +209,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	@Override
 	public StudyMembersResponse findStudyMembersById(Long studyOnceId) {
 		StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
-		List<MemberResponse> memberResponses = studyOnce.getStudyMembers().stream()
-			.map(studyMember -> new MemberResponse(
-				studyMember.getMember().getId(),
-				studyMember.getMember().getName(),
-				studyMember.getMember().getThumbnailImage().getThumbnailImage()))
-			.collect(Collectors.toList());
+		List<MemberResponse> memberResponses = studyMemberMapper.toMemberResponses(studyOnce.getStudyMembers());
 		return new StudyMembersResponse(memberResponses);
 	}
 

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -192,10 +192,18 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		return leader;
 	}
 
-	public Long changeCafe(Long studyOnceId, final Long changingCafeId) {
+	public Long changeCafe(Long requestMemberId, Long studyOnceId, final Long changingCafeId) {
 		final StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
+		if (!studyOnce.isLeader(findMemberById(requestMemberId))) {
+			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
+		}
 		studyOnce.changeCafe(findCafeById(changingCafeId));
 		return changingCafeId;
+	}
+
+	private MemberImpl findMemberById(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new CafegoryException(MEMBER_NOT_FOUND));
 	}
 
 	private CafeImpl findCafeById(Long cafeId) {

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -192,6 +192,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		return leader;
 	}
 
+	@Override
 	public Long changeCafe(Long requestMemberId, Long studyOnceId, final Long changingCafeId) {
 		final StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
 		if (!studyOnce.isLeader(findMemberById(requestMemberId))) {

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -197,7 +197,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	@Override
 	public Long changeCafe(Long requestMemberId, Long studyOnceId, final Long changingCafeId) {
 		final StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
-		if (!studyOnce.isLeader(findMemberById(requestMemberId))) {
+		if (!isStudyOnceLeader(requestMemberId, studyOnceId)) {
 			throw new CafegoryException(STUDY_ONCE_INVALID_LEADER);
 		}
 		studyOnce.changeCafe(findCafeById(changingCafeId));
@@ -214,6 +214,12 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 				studyMember.getMember().getThumbnailImage().getThumbnailImage()))
 			.collect(Collectors.toList());
 		return new StudyMembersResponse(memberResponses);
+	}
+
+	@Override
+	public boolean isStudyOnceLeader(Long memberId, Long studyOnceId) {
+		StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
+		return studyOnce.isLeader(findMemberById(memberId));
 	}
 
 	private MemberImpl findMemberById(Long memberId) {

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -192,4 +192,14 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		return leader;
 	}
 
+	public Long changeCafe(Long studyOnceId, final Long changingCafeId) {
+		final StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
+		studyOnce.changeCafe(findCafeById(changingCafeId));
+		return changingCafeId;
+	}
+
+	private CafeImpl findCafeById(Long cafeId) {
+		return cafeRepository.findById(cafeId)
+			.orElseThrow(() -> new CafegoryException(CAFE_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/StudyOnceServiceImpl.java
@@ -16,9 +16,11 @@ import com.example.demo.domain.MemberImpl;
 import com.example.demo.domain.StudyMember;
 import com.example.demo.domain.StudyMemberId;
 import com.example.demo.domain.StudyOnceImpl;
+import com.example.demo.dto.MemberResponse;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyMemberStateRequest;
 import com.example.demo.dto.StudyMemberStateResponse;
+import com.example.demo.dto.StudyMembersResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
@@ -200,6 +202,18 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		}
 		studyOnce.changeCafe(findCafeById(changingCafeId));
 		return changingCafeId;
+	}
+
+	@Override
+	public StudyMembersResponse findStudyMembersById(Long studyOnceId) {
+		StudyOnceImpl studyOnce = findStudyOnceById(studyOnceId);
+		List<MemberResponse> memberResponses = studyOnce.getStudyMembers().stream()
+			.map(studyMember -> new MemberResponse(
+				studyMember.getMember().getId(),
+				studyMember.getMember().getName(),
+				studyMember.getMember().getThumbnailImage().getThumbnailImage()))
+			.collect(Collectors.toList());
+		return new StudyMembersResponse(memberResponses);
 	}
 
 	private MemberImpl findMemberById(Long memberId) {

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -654,7 +654,7 @@ class StudyOnceServiceImplTest {
 		assertThatThrownBy(
 			() -> studyOnceService.changeCafe(otherPerson.getId(), studyOnce.getId(), changingCafe.getId()))
 			.isInstanceOf(CafegoryException.class)
-			.hasMessage(ExceptionType.STUDY_ONCE_INVALID_LEADER.getErrorMessage());
+			.hasMessage(ExceptionType.STUDY_ONCE_LOCATION_CHANGE_PERMISSION_DENIED.getErrorMessage());
 	}
 
 	@Test

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -31,8 +31,10 @@ import com.example.demo.domain.StudyMember;
 import com.example.demo.domain.StudyMemberId;
 import com.example.demo.domain.StudyOnceImpl;
 import com.example.demo.domain.ThumbnailImage;
+import com.example.demo.dto.MemberResponse;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.StudyMemberStateRequest;
+import com.example.demo.dto.StudyMembersResponse;
 import com.example.demo.dto.StudyOnceCreateRequest;
 import com.example.demo.dto.StudyOnceSearchRequest;
 import com.example.demo.dto.StudyOnceSearchResponse;
@@ -446,7 +448,7 @@ class StudyOnceServiceImplTest {
 		studyMemberPersistHelper.persistDefaultStudyMember(member, studyOnce);
 		//then
 		assertThatThrownBy(() ->
-			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), 10L, Attendance.NO,
+			studyOnceService.updateAttendance(leader.getId(), studyOnce.getId(), 999L, Attendance.NO,
 				LocalDateTime.of(2999, 2, 17, 18, 10))
 		).isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_MEMBER_NOT_FOUND.getErrorMessage());
@@ -654,5 +656,28 @@ class StudyOnceServiceImplTest {
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(ExceptionType.STUDY_ONCE_INVALID_LEADER.getErrorMessage());
 	}
+
+	@Test
+	@DisplayName("카공 참여자 정보 조회")
+	void findStudyMembers() {
+		//given
+		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
+		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "카공장");
+		MemberImpl member1 = memberPersistHelper.persistMemberWithName(thumb, "김동현");
+		MemberImpl member2 = memberPersistHelper.persistMemberWithName(thumb, "임수빈");
+		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
+		StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		studyMemberPersistHelper.persistDefaultStudyMember(member1, studyOnce);
+		studyMemberPersistHelper.persistDefaultStudyMember(member2, studyOnce);
+		em.flush();
+		em.clear();
+		//when
+		StudyMembersResponse response = studyOnceService.findStudyMembersById(studyOnce.getId());
+		List<MemberResponse> joinedMembers = response.getJoinedMembers();
+		//then
+		assertThat(joinedMembers.size()).isEqualTo(3);
+	}
+
+	//참여자가 존재하지 않으면 빈 리스트를 반환한다.
 
 }

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -678,6 +678,4 @@ class StudyOnceServiceImplTest {
 		assertThat(joinedMembers.size()).isEqualTo(3);
 	}
 
-	//참여자가 존재하지 않으면 빈 리스트를 반환한다.
-
 }

--- a/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/StudyOnceServiceImplTest.java
@@ -593,4 +593,23 @@ class StudyOnceServiceImplTest {
 			.contains(Attendance.NO);
 	}
 
+	@Test
+	@DisplayName("카공 카페 장소를 변경할 수 있다.")
+	void changeCafe() {
+		//given
+		ThumbnailImage thumb = thumbnailImagePersistHelper.persistDefaultThumbnailImage();
+		MemberImpl leader = memberPersistHelper.persistMemberWithName(thumb, "카공장");
+		CafeImpl cafe = cafePersistHelper.persistDefaultCafe();
+		CafeImpl changingCafe = cafePersistHelper.persistDefaultCafe();
+		StudyOnceImpl studyOnce = studyOncePersistHelper.persistDefaultStudyOnce(cafe, leader);
+		//when
+		studyOnceService.changeCafe(studyOnce.getId(), changingCafe.getId());
+		//then
+		assertThat(studyOnce.getCafe().getId()).isEqualTo(changingCafe.getId());
+	}
+
+	//카공장만이 카페 장소를 변경할 수 있다.
+
+	//카공장이 아니라면 예외가 터진다.
+
 }


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항
카공 장소 변경 api
1. 카공장은 카공을 진행하는 카페를 변경할 수 있다.
2. 카공장'만' 카페를 변경 할 수 있다.

카공 참여자 정보 조회 api
1. 카공 참여자 정보 리스트를 조회한다.
# 의견 좀 주세요
![image](https://github.com/Cafegory/Cafegory_Backend_REST_API/assets/127406465/e75977d2-22c5-45e5-96db-4bbbd6b5dd9c)
매핑 로직은 mapper 에게 위임할 예정입니다.

**질문**
엔티티와 dto의 매핑은 어느정도 디미터의 법칙을 위반할 수 밖에 없다고 생각합니다.
1. 위와 같이 `studyMember.getMember().getThumbnailImage().getThumbnailImage()` 의 형식으로 작성하는게 맞는것인지
아니면
2. StudyMember 엔티티에게 `Long getMemberId( this.getMember().getId() );` 
`Long getThumbnailImage(){ return this.getMember().getThumbnailImage().getThumbnailImage()}`
와 같은 형식으로 위임하는게 낫다고 생각하시나요?
두번째 방식으로 한다면, 연관관계 엔티티들의 필드가 추가될때마다 똑같이 메서드를 만들어 줘야할까요?

이 두가지가 자꾸 머릿속에서 충돌이 나네요
의견 부탁드려요!!


close #55  