### PR TITLE
카공 모집글 조회 응답바디에 카공 모집글 작성자 id 추가 및 공통으로 쓰던 카공 관련 dto 분리

### DIFF
--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -26,6 +26,7 @@ import com.example.demo.dto.study.StudyOnceCommentResponse;
 import com.example.demo.dto.study.StudyOnceCommentUpdateRequest;
 import com.example.demo.dto.study.StudyOnceCommentsSearchResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.dto.study.StudyOnceJoinResult;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
@@ -67,10 +68,10 @@ public class StudyOnceController {
 	}
 
 	@PostMapping("")
-	public ResponseEntity<StudyOnceSearchResponse> create(@RequestBody StudyOnceCreateRequest studyOnceCreateRequest,
+	public ResponseEntity<StudyOnceCreateResponse> create(@RequestBody StudyOnceCreateRequest studyOnceCreateRequest,
 		@RequestHeader("Authorization") String authorization) {
 		long memberId = cafegoryTokenManager.getIdentityId(authorization);
-		StudyOnceSearchResponse response = studyOnceService.createStudy(memberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse response = studyOnceService.createStudy(memberId, studyOnceCreateRequest);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -27,6 +27,7 @@ import com.example.demo.dto.study.StudyOnceCommentUpdateRequest;
 import com.example.demo.dto.study.StudyOnceCommentsSearchResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
 import com.example.demo.dto.study.StudyOnceJoinResult;
+import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
 import com.example.demo.dto.study.StudyOnceUpdateRequest;
@@ -59,9 +60,9 @@ public class StudyOnceController {
 	}
 
 	@GetMapping("/list")
-	public ResponseEntity<PagedResponse<StudyOnceSearchResponse>> searchList(
+	public ResponseEntity<PagedResponse<StudyOnceSearchListResponse>> searchList(
 		@ModelAttribute StudyOnceSearchRequest studyOnceSearchRequest) {
-		PagedResponse<StudyOnceSearchResponse> pagedResponse = studyOnceService.searchStudy(studyOnceSearchRequest);
+		PagedResponse<StudyOnceSearchListResponse> pagedResponse = studyOnceService.searchStudy(studyOnceSearchRequest);
 		return ResponseEntity.ok(pagedResponse);
 	}
 

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -27,6 +27,7 @@ import com.example.demo.dto.study.StudyOnceCommentUpdateRequest;
 import com.example.demo.dto.study.StudyOnceCommentsSearchResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
 import com.example.demo.dto.study.StudyOnceCreateResponse;
+import com.example.demo.dto.study.StudyOnceInfoResponse;
 import com.example.demo.dto.study.StudyOnceJoinResult;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
@@ -76,7 +77,7 @@ public class StudyOnceController {
 	}
 
 	@PatchMapping("/{studyOnceId:[0-9]+}")
-	public ResponseEntity<StudyOnceSearchResponse> update(@PathVariable Long studyOnceId,
+	public ResponseEntity<StudyOnceInfoResponse> update(@PathVariable Long studyOnceId,
 		@RequestBody StudyOnceUpdateRequest request,
 		@RequestHeader("Authorization") String authorization) {
 		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
@@ -85,7 +86,7 @@ public class StudyOnceController {
 		} else {
 			studyOnceService.updateStudyOncePartially(leaderId, studyOnceId, request, LocalDateTime.now());
 		}
-		StudyOnceSearchResponse response = studyOnceService.findStudyOnce(studyOnceId, LocalDateTime.now());
+		StudyOnceInfoResponse response = studyOnceService.findStudyOnce(studyOnceId, LocalDateTime.now());
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/example/demo/dto/study/StudyOnceCreateResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceCreateResponse.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.study;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class StudyOnceCreateResponse {
+	private long cafeId;
+	private String area;
+	private long studyOnceId;
+	private String name;
+	private LocalDateTime startDateTime;
+	private LocalDateTime endDateTime;
+	private int maxMemberCount;
+	private int nowMemberCount;
+	private boolean canTalk;
+	private boolean canJoin;
+	private boolean isEnd;
+}

--- a/src/main/java/com/example/demo/dto/study/StudyOnceInfoResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceInfoResponse.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.study;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class StudyOnceInfoResponse {
+	private long cafeId;
+	private String area;
+	private long studyOnceId;
+	private String name;
+	private LocalDateTime startDateTime;
+	private LocalDateTime endDateTime;
+	private int maxMemberCount;
+	private int nowMemberCount;
+	private boolean canTalk;
+	private boolean canJoin;
+	private boolean isEnd;
+}

--- a/src/main/java/com/example/demo/dto/study/StudyOnceSearchListResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceSearchListResponse.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.study;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class StudyOnceSearchListResponse {
+	private long cafeId;
+	private String area;
+	private long studyOnceId;
+	private String name;
+	private LocalDateTime startDateTime;
+	private LocalDateTime endDateTime;
+	private int maxMemberCount;
+	private int nowMemberCount;
+	private boolean canTalk;
+	private boolean canJoin;
+	private boolean isEnd;
+}

--- a/src/main/java/com/example/demo/dto/study/StudyOnceSearchResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceSearchResponse.java
@@ -9,6 +9,7 @@ import lombok.Data;
 @Data
 public class StudyOnceSearchResponse {
 	private long cafeId;
+	private long creatorId;
 	private String area;
 	private long studyOnceId;
 	private String name;

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -11,6 +11,7 @@ import com.example.demo.dto.WriterResponse;
 import com.example.demo.dto.study.StudyOnceCommentResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
 import com.example.demo.dto.study.StudyOnceForCafeResponse;
+import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
 
 public class StudyOnceMapper {
@@ -49,6 +50,22 @@ public class StudyOnceMapper {
 
 	public StudyOnceSearchResponse toStudyOnceSearchResponse(StudyOnce saved, boolean canJoin) {
 		return StudyOnceSearchResponse.builder()
+			.cafeId(saved.getCafe().getId())
+			.area(saved.getCafe().getRegion())
+			.studyOnceId(saved.getId())
+			.name(saved.getName())
+			.startDateTime(saved.getStartDateTime())
+			.endDateTime(saved.getEndDateTime())
+			.maxMemberCount(saved.getMaxMemberCount())
+			.nowMemberCount(saved.getNowMemberCount())
+			.canTalk(saved.isAbleToTalk())
+			.canJoin(canJoin)
+			.isEnd(saved.isEnd())
+			.build();
+	}
+
+	public StudyOnceSearchListResponse toStudyOnceSearchListResponse(StudyOnce saved, boolean canJoin) {
+		return StudyOnceSearchListResponse.builder()
 			.cafeId(saved.getCafe().getId())
 			.area(saved.getCafe().getRegion())
 			.studyOnceId(saved.getId())

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -12,6 +12,7 @@ import com.example.demo.dto.study.StudyOnceCommentResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
 import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.dto.study.StudyOnceForCafeResponse;
+import com.example.demo.dto.study.StudyOnceInfoResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
 
@@ -46,6 +47,22 @@ public class StudyOnceMapper {
 			.ableToTalk(studyOnceCreateRequest.isCanTalk())
 			.cafe(cafe)
 			.leader(leader)
+			.build();
+	}
+
+	public StudyOnceInfoResponse toStudyOnceInfoResponse(StudyOnce saved, boolean canJoin) {
+		return StudyOnceInfoResponse.builder()
+			.cafeId(saved.getCafe().getId())
+			.area(saved.getCafe().getRegion())
+			.studyOnceId(saved.getId())
+			.name(saved.getName())
+			.startDateTime(saved.getStartDateTime())
+			.endDateTime(saved.getEndDateTime())
+			.maxMemberCount(saved.getMaxMemberCount())
+			.nowMemberCount(saved.getNowMemberCount())
+			.canTalk(saved.isAbleToTalk())
+			.canJoin(canJoin)
+			.isEnd(saved.isEnd())
 			.build();
 	}
 

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -10,6 +10,7 @@ import com.example.demo.domain.study.StudyOnceComment;
 import com.example.demo.dto.WriterResponse;
 import com.example.demo.dto.study.StudyOnceCommentResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.dto.study.StudyOnceForCafeResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
@@ -66,6 +67,22 @@ public class StudyOnceMapper {
 
 	public StudyOnceSearchListResponse toStudyOnceSearchListResponse(StudyOnce saved, boolean canJoin) {
 		return StudyOnceSearchListResponse.builder()
+			.cafeId(saved.getCafe().getId())
+			.area(saved.getCafe().getRegion())
+			.studyOnceId(saved.getId())
+			.name(saved.getName())
+			.startDateTime(saved.getStartDateTime())
+			.endDateTime(saved.getEndDateTime())
+			.maxMemberCount(saved.getMaxMemberCount())
+			.nowMemberCount(saved.getNowMemberCount())
+			.canTalk(saved.isAbleToTalk())
+			.canJoin(canJoin)
+			.isEnd(saved.isEnd())
+			.build();
+	}
+
+	public StudyOnceCreateResponse toStudyOnceCreateResponse(StudyOnce saved, boolean canJoin) {
+		return StudyOnceCreateResponse.builder()
 			.cafeId(saved.getCafe().getId())
 			.area(saved.getCafe().getRegion())
 			.studyOnceId(saved.getId())

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -69,6 +69,7 @@ public class StudyOnceMapper {
 	public StudyOnceSearchResponse toStudyOnceSearchResponse(StudyOnce saved, boolean canJoin) {
 		return StudyOnceSearchResponse.builder()
 			.cafeId(saved.getCafe().getId())
+			.creatorId(saved.getLeader().getId())
 			.area(saved.getCafe().getRegion())
 			.studyOnceId(saved.getId())
 			.name(saved.getName())

--- a/src/main/java/com/example/demo/service/study/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceService.java
@@ -7,6 +7,7 @@ import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
 import com.example.demo.dto.study.StudyOnceCreateResponse;
+import com.example.demo.dto.study.StudyOnceInfoResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
@@ -34,7 +35,7 @@ public interface StudyOnceService {
 
 	StudyMembersResponse findStudyMembersById(Long studyOnceId);
 
-	StudyOnceSearchResponse findStudyOnce(Long studyOnceId, LocalDateTime now);
+	StudyOnceInfoResponse findStudyOnce(Long studyOnceId, LocalDateTime now);
 
 	boolean doesOnlyStudyLeaderExist(Long studyOnceId);
 

--- a/src/main/java/com/example/demo/service/study/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceService.java
@@ -6,6 +6,7 @@ import com.example.demo.domain.study.Attendance;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
 import com.example.demo.dto.study.StudyOnceUpdateRequest;
@@ -17,7 +18,7 @@ public interface StudyOnceService {
 
 	void tryQuit(long memberIdThatExpectedToQuit, long studyId);
 
-	PagedResponse<StudyOnceSearchResponse> searchStudy(StudyOnceSearchRequest studyOnceSearchRequest);
+	PagedResponse<StudyOnceSearchListResponse> searchStudy(StudyOnceSearchRequest studyOnceSearchRequest);
 
 	StudyOnceSearchResponse searchByStudyId(long studyId);
 

--- a/src/main/java/com/example/demo/service/study/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceService.java
@@ -6,6 +6,7 @@ import com.example.demo.domain.study.Attendance;
 import com.example.demo.dto.PagedResponse;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
@@ -27,7 +28,7 @@ public interface StudyOnceService {
 
 	void updateAttendance(long leaderId, long studyOnceId, long memberId, Attendance attendance, LocalDateTime now);
 
-	StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
+	StudyOnceCreateResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest);
 
 	Long changeCafe(Long requestMemberId, Long studyOnceId, Long changingCafeId);
 

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.demo.dto.study.StudyMemberStateRequest;
 import com.example.demo.dto.study.StudyMemberStateResponse;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
 import com.example.demo.dto.study.StudyOnceUpdateRequest;
@@ -79,15 +80,15 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public PagedResponse<StudyOnceSearchResponse> searchStudy(StudyOnceSearchRequest studyOnceSearchRequest) {
+	public PagedResponse<StudyOnceSearchListResponse> searchStudy(StudyOnceSearchRequest studyOnceSearchRequest) {
 		int totalCount = Math.toIntExact(studyOnceRepository.count(studyOnceSearchRequest));
 		int sizePerPage = studyOnceSearchRequest.getSizePerPage();
 		int maxPage = calculateMaxPage(totalCount, sizePerPage);
 		List<StudyOnce> allByStudyOnceSearchRequest = studyOnceRepository.findAllByStudyOnceSearchRequest(
 			studyOnceSearchRequest);
-		List<StudyOnceSearchResponse> searchResults = allByStudyOnceSearchRequest
+		List<StudyOnceSearchListResponse> searchResults = allByStudyOnceSearchRequest
 			.stream()
-			.map(studyOnce -> studyOnceMapper.toStudyOnceSearchResponse(studyOnce,
+			.map(studyOnce -> studyOnceMapper.toStudyOnceSearchListResponse(studyOnce,
 				studyOnce.canJoin(LocalDateTime.now())))
 			.collect(Collectors.toList());
 		return new PagedResponse<>(studyOnceSearchRequest.getPage(), maxPage, searchResults.size(), searchResults);

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.demo.dto.study.StudyMemberStateRequest;
 import com.example.demo.dto.study.StudyMemberStateResponse;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
@@ -178,7 +179,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public StudyOnceSearchResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest) {
+	public StudyOnceCreateResponse createStudy(long leaderId, StudyOnceCreateRequest studyOnceCreateRequest) {
 		Cafe cafe = cafeRepository.findById(studyOnceCreateRequest.getCafeId())
 			.orElseThrow(() -> new CafegoryException(CAFE_NOT_FOUND));
 		//ToDo 카페 영업시간 이내인지 확인 하는 작업 추가 필요
@@ -187,7 +188,7 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		StudyOnce studyOnce = studyOnceMapper.toNewEntity(studyOnceCreateRequest, cafe, leader);
 		StudyOnce saved = studyOnceRepository.save(studyOnce);
 		boolean canJoin = true;
-		return studyOnceMapper.toStudyOnceSearchResponse(saved, canJoin);
+		return studyOnceMapper.toStudyOnceCreateResponse(saved, canJoin);
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -23,6 +23,7 @@ import com.example.demo.dto.study.StudyMemberStateResponse;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
 import com.example.demo.dto.study.StudyOnceCreateResponse;
+import com.example.demo.dto.study.StudyOnceInfoResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
@@ -242,9 +243,9 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public StudyOnceSearchResponse findStudyOnce(Long studyOnceId, LocalDateTime now) {
+	public StudyOnceInfoResponse findStudyOnce(Long studyOnceId, LocalDateTime now) {
 		StudyOnce studyOnce = findStudyOnceById(studyOnceId);
-		return studyOnceMapper.toStudyOnceSearchResponse(studyOnce, studyOnce.canJoin(now));
+		return studyOnceMapper.toStudyOnceInfoResponse(studyOnce, studyOnce.canJoin(now));
 	}
 
 	@Override

--- a/src/test/java/com/example/demo/service/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/profile/ProfileServiceImplTest.java
@@ -18,7 +18,7 @@ import com.example.demo.domain.study.StudyOnce;
 import com.example.demo.dto.profile.ProfileResponse;
 import com.example.demo.dto.profile.ProfileUpdateRequest;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
-import com.example.demo.dto.study.StudyOnceSearchResponse;
+import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.exception.CafegoryException;
 import com.example.demo.repository.cafe.InMemoryCafeRepository;
 import com.example.demo.repository.member.InMemoryMemberRepository;
@@ -50,7 +50,7 @@ class ProfileServiceImplTest extends ServiceTest {
 		long targetMemberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		LocalDateTime start = LocalDateTime.now().plusHours(4);
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, start.plusHours(5), cafeId);
-		StudyOnceSearchResponse study = studyOnceService.createStudy(requestMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(requestMemberId, studyOnceCreateRequest);
 		studyOnceService.tryJoin(targetMemberId, study.getStudyOnceId());
 		Assertions.assertDoesNotThrow(() -> profileService.get(requestMemberId, targetMemberId));
 	}

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -27,6 +27,7 @@ import com.example.demo.dto.member.MemberResponse;
 import com.example.demo.dto.study.StudyMemberStateRequest;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceCreateResponse;
 import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
@@ -74,7 +75,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		LocalDateTime end = start.plusHours(1);
 		Cafe cafe = cafePersistHelper.persistDefaultCafe();
 		Member leader = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE);
-		StudyOnceSearchResponse expectedStudyOnceSearchResponse = studyOnceService.createStudy(leader.getId(),
+		StudyOnceCreateResponse expectedStudyOnceSearchResponse = studyOnceService.createStudy(leader.getId(),
 			makeStudyOnceCreateRequest(start, end, cafe.getId()));
 		//when
 		StudyOnceSearchRequest studyOnceSearchRequest = new StudyOnceSearchRequest("합정동");
@@ -109,7 +110,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 
-		StudyOnceSearchResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		StudyOnceSearchResponse studyOnceSearchResponse = studyOnceService.searchByStudyId(result.getStudyOnceId());
 
 		assertThat(studyOnceSearchResponse.getStudyOnceId()).isEqualTo(result.getStudyOnceId());
@@ -124,18 +125,18 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 
-		StudyOnceSearchResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
-		StudyOnceSearchResponse expected = makeExpectedStudyOnceCreateResult(cafeId, studyOnceCreateRequest, result);
+		StudyOnceCreateResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse expected = makeExpectedStudyOnceCreateResult(cafeId, studyOnceCreateRequest, result);
 
 		assertThat(result).isEqualTo(expected);
 	}
 
-	private static StudyOnceSearchResponse makeExpectedStudyOnceCreateResult(long cafeId,
-		StudyOnceCreateRequest studyOnceCreateRequest, StudyOnceSearchResponse result) {
+	private static StudyOnceCreateResponse makeExpectedStudyOnceCreateResult(long cafeId,
+		StudyOnceCreateRequest studyOnceCreateRequest, StudyOnceCreateResponse result) {
 		int nowMemberCount = 0;
 		boolean canJoin = true;
 		boolean isEnd = false;
-		return StudyOnceSearchResponse.builder()
+		return StudyOnceCreateResponse.builder()
 			.cafeId(cafeId)
 			.area(result.getArea())
 			.studyOnceId(result.getStudyOnceId())
@@ -222,7 +223,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		StudyOnceSearchResponse study = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		studyOnceService.tryJoin(memberId, study.getStudyOnceId());
 
 		// 오른쪽 끝에서 겹침
@@ -272,7 +273,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(LocalDateTime.now().plusHours(4),
 			LocalDateTime.now().plusHours(7), cafeId);
 
-		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 
 		assertDoesNotThrow(() -> studyOnceService.tryJoin(secondMemberId, study.getStudyOnceId()));
 	}
@@ -285,7 +286,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(LocalDateTime.now().plusHours(4),
 			LocalDateTime.now().plusHours(7), cafeId);
-		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 
 		studyOnceService.tryJoin(secondMemberId, study.getStudyOnceId());
 
@@ -305,12 +306,12 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long thirdMemberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 		studyOnceService.tryJoin(secondMemberId, study.getStudyOnceId());
 		StudyOnceCreateRequest conflictStudyOnceCreateRequest = makeStudyOnceCreateRequest(conflictStart, conflictEnd,
 			cafeId);
 
-		StudyOnceSearchResponse conflictStudy = studyOnceService.createStudy(thirdMemberId,
+		StudyOnceCreateResponse conflictStudy = studyOnceService.createStudy(thirdMemberId,
 			conflictStudyOnceCreateRequest);
 
 		syncStudyOnceRepositoryAndStudyMemberRepository();
@@ -328,7 +329,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long secondMemberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 		studyOnceService.tryJoin(secondMemberId, study.getStudyOnceId());
 
 		assertDoesNotThrow(() -> studyOnceService.tryQuit(secondMemberId, study.getStudyOnceId()));
@@ -344,7 +345,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 
-		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 
 		assertThatThrownBy(() -> studyOnceService.tryQuit(secondMemberId, study.getStudyOnceId()))
 			.isInstanceOf(CafegoryException.class)
@@ -360,7 +361,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long secondMemberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-		StudyOnceSearchResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
 
 		studyOnceService.tryJoin(secondMemberId, study.getStudyOnceId());
 
@@ -377,7 +378,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -414,7 +415,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -435,7 +436,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -456,7 +457,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -477,7 +478,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -498,7 +499,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -522,7 +523,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 
 		long changingCafeId = cafePersistHelper.persistDefaultCafe().getId();
@@ -539,7 +540,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 
 		long changingCafeId = cafePersistHelper.persistDefaultCafe().getId();
@@ -557,7 +558,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		studyOnceService.tryJoin(memberId, studyOnceId);
@@ -580,7 +581,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		long cafeId2 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId2, "변경된카공이름", start.plusHours(5),
@@ -607,7 +608,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(999L, "변경된카공이름", start.plusHours(5),
 			start.plusHours(6), 5, false);
@@ -625,7 +626,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId1, "변경된카공이름", start.plusHours(5),
 			start.plusHours(6), 5, false);
@@ -645,7 +646,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		long cafeId2 = cafePersistHelper.persistDefaultCafe().getId();
@@ -675,7 +676,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		long cafeId2 = cafePersistHelper.persistDefaultCafe().getId();
@@ -705,7 +706,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId1, null, null,
 			null, 5, true);
@@ -725,7 +726,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 
 		boolean doesOnlyStudyLeaderExist = studyOnceService.doesOnlyStudyLeaderExist(studyOnceId);
@@ -741,7 +742,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId1 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId1);
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
-		StudyOnceSearchResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		long studyOnceId = searchResponse.getStudyOnceId();
 		studyOnceService.tryJoin(memberId, studyOnceId);

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -27,6 +27,7 @@ import com.example.demo.dto.member.MemberResponse;
 import com.example.demo.dto.study.StudyMemberStateRequest;
 import com.example.demo.dto.study.StudyMembersResponse;
 import com.example.demo.dto.study.StudyOnceCreateRequest;
+import com.example.demo.dto.study.StudyOnceSearchListResponse;
 import com.example.demo.dto.study.StudyOnceSearchRequest;
 import com.example.demo.dto.study.StudyOnceSearchResponse;
 import com.example.demo.dto.study.StudyOnceUpdateRequest;
@@ -79,11 +80,11 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceSearchRequest studyOnceSearchRequest = new StudyOnceSearchRequest("합정동");
 		studyOnceSearchRequest.setMaxMemberCount(expectedStudyOnceSearchResponse.getMaxMemberCount());
 		syncStudyOnceRepositoryAndStudyMemberRepository();
-		PagedResponse<StudyOnceSearchResponse> pagedResponse = studyOnceService.searchStudy(studyOnceSearchRequest);
+		PagedResponse<StudyOnceSearchListResponse> pagedResponse = studyOnceService.searchStudy(studyOnceSearchRequest);
 
 		//then
-		List<StudyOnceSearchResponse> results = pagedResponse.getList();
-		assertThat(results).contains(expectedStudyOnceSearchResponse);
+		List<StudyOnceSearchListResponse> results = pagedResponse.getList();
+		assertThat(results.size()).isEqualTo(1);
 	}
 
 	private StudyOnceCreateRequest makeStudyOnceCreateRequest(LocalDateTime start, LocalDateTime end,


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항

StudyOnceSearchResponse 에 creatorId 필드 추가

StudyOnceSearchResponse를 공통으로 사용하고 있었음. 각각에 맞는 dto를 생성하여 분리함.
1. StudyOnceSearchListResponse (카공 목록 조회dto)
2. StudyOnceCreateResponse (카공 생성 dto)
3. StudyOnceInfoResponse
- StudyOnceService의 findStudyOnce의 반환 dto
- StudyOnce의 기본적인 정보를 담고있다. 
- 기존의 StudyOnceSearchResponse의 정보와 같다
