### PR TITLE
[BUILD SUCCESS] 카공에 오픈채팅방url 추가 및 카공 모집글 생성, 카공 모집글 수정에 오픈채팅방 url 넣을 수 있도록 변경, 카공모집글 조회에 참여한 상태 추가

### DIFF
--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -79,7 +79,7 @@ public class StudyOnceController {
 
 	@PatchMapping("/{studyOnceId:[0-9]+}")
 	public ResponseEntity<StudyOnceInfoResponse> update(@PathVariable Long studyOnceId,
-		@RequestBody StudyOnceUpdateRequest request,
+		@RequestBody @Validated StudyOnceUpdateRequest request,
 		@RequestHeader("Authorization") String authorization) {
 		long leaderId = cafegoryTokenManager.getIdentityId(authorization);
 		if (studyOnceService.doesOnlyStudyLeaderExist(studyOnceId)) {

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -69,7 +69,8 @@ public class StudyOnceController {
 	}
 
 	@PostMapping("")
-	public ResponseEntity<StudyOnceCreateResponse> create(@RequestBody StudyOnceCreateRequest studyOnceCreateRequest,
+	public ResponseEntity<StudyOnceCreateResponse> create(
+		@RequestBody @Validated StudyOnceCreateRequest studyOnceCreateRequest,
 		@RequestHeader("Authorization") String authorization) {
 		long memberId = cafegoryTokenManager.getIdentityId(authorization);
 		StudyOnceCreateResponse response = studyOnceService.createStudy(memberId, studyOnceCreateRequest);

--- a/src/main/java/com/example/demo/controller/StudyOnceController.java
+++ b/src/main/java/com/example/demo/controller/StudyOnceController.java
@@ -4,7 +4,9 @@ import static com.example.demo.exception.ExceptionType.*;
 
 import java.time.LocalDateTime;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,7 +58,14 @@ public class StudyOnceController {
 	private final StudyOnceCommentQueryService studyOnceCommentQueryService;
 
 	@GetMapping("/{studyOnceId:[0-9]+}")
-	public ResponseEntity<StudyOnceSearchResponse> search(@PathVariable Long studyOnceId) {
+	public ResponseEntity<StudyOnceSearchResponse> search(@PathVariable Long studyOnceId,
+		@RequestHeader(value = "Authorization", required = false) String authorization) {
+		if (StringUtils.hasText(authorization)) {
+			long memberId = cafegoryTokenManager.getIdentityId(authorization);
+			StudyOnceSearchResponse response = studyOnceService.searchStudyOnceWithMemberParticipation(studyOnceId,
+				memberId);
+			return new ResponseEntity<>(response, HttpStatus.OK);
+		}
 		StudyOnceSearchResponse response = studyOnceService.searchByStudyId(studyOnceId);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/example/demo/domain/study/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/study/StudyOnce.java
@@ -72,6 +72,7 @@ public class StudyOnce {
 		validateStudyOnceTime(startDateTime, endDateTime);
 		validateMaxMemberCount(maxMemberCount);
 		this.id = id;
+		validateEmptyOrWhiteSpace(name, STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE);
 		this.name = name;
 		this.cafe = cafe;
 		this.startDateTime = startDateTime;
@@ -81,6 +82,7 @@ public class StudyOnce {
 		this.nowMemberCount = nowMemberCount;
 		this.isEnd = isEnd;
 		this.ableToTalk = ableToTalk;
+		validateEmptyOrWhiteSpace(openChatUrl, STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE);
 		this.openChatUrl = openChatUrl;
 		this.leader = leader;
 		validateConflictJoin(leader);
@@ -183,9 +185,7 @@ public class StudyOnce {
 	}
 
 	public void changeName(String name) {
-		if (StringUtils.isEmptyOrWhitespace(name)) {
-			throw new CafegoryException(STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE);
-		}
+		validateEmptyOrWhiteSpace(name, STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE);
 		this.name = name;
 	}
 
@@ -210,4 +210,14 @@ public class StudyOnce {
 		return this.studyMembers.size() == 1 && this.studyMembers.get(0).isLeader(this.leader);
 	}
 
+	public void changeOpenChatUrl(String openChatUrl) {
+		validateEmptyOrWhiteSpace(openChatUrl, STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE);
+		this.openChatUrl = openChatUrl;
+	}
+
+	private void validateEmptyOrWhiteSpace(String target, ExceptionType exceptionType) {
+		if (StringUtils.isEmptyOrWhitespace(target)) {
+			throw new CafegoryException(exceptionType);
+		}
+	}
 }

--- a/src/main/java/com/example/demo/domain/study/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/study/StudyOnce.java
@@ -58,6 +58,7 @@ public class StudyOnce {
 	private int nowMemberCount;
 	private boolean isEnd;
 	private boolean ableToTalk;
+	private String openChatUrl;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "leader_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private Member leader;
@@ -66,7 +67,7 @@ public class StudyOnce {
 
 	@Builder
 	private StudyOnce(Long id, String name, Cafe cafe, LocalDateTime startDateTime, LocalDateTime endDateTime,
-		int maxMemberCount, int nowMemberCount, boolean isEnd, boolean ableToTalk, Member leader) {
+		int maxMemberCount, int nowMemberCount, boolean isEnd, boolean ableToTalk, String openChatUrl, Member leader) {
 		validateStartDateTime(startDateTime);
 		validateStudyOnceTime(startDateTime, endDateTime);
 		validateMaxMemberCount(maxMemberCount);
@@ -80,6 +81,7 @@ public class StudyOnce {
 		this.nowMemberCount = nowMemberCount;
 		this.isEnd = isEnd;
 		this.ableToTalk = ableToTalk;
+		this.openChatUrl = openChatUrl;
 		this.leader = leader;
 		validateConflictJoin(leader);
 		studyMembers = new ArrayList<>();

--- a/src/main/java/com/example/demo/domain/study/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/study/StudyOnce.java
@@ -220,4 +220,9 @@ public class StudyOnce {
 			throw new CafegoryException(exceptionType);
 		}
 	}
+
+	public boolean isAttendance(Member member) {
+		return studyMembers.stream()
+			.anyMatch(s -> s.getId().getMemberId().equals(member.getId()));
+	}
 }

--- a/src/main/java/com/example/demo/dto/study/StudyOnceCreateRequest.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceCreateRequest.java
@@ -2,6 +2,8 @@ package com.example.demo.dto.study;
 
 import java.time.LocalDateTime;
 
+import javax.validation.constraints.NotBlank;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,10 +13,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StudyOnceCreateRequest {
 	private long cafeId;
+	@NotBlank
 	private String name;
 	private LocalDateTime startDateTime;
 	private LocalDateTime endDateTime;
 	private int maxMemberCount;
 	private boolean canTalk;
+	@NotBlank
+	private String openChatUrl;
 }
 

--- a/src/main/java/com/example/demo/dto/study/StudyOnceCreateResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceCreateResponse.java
@@ -19,4 +19,5 @@ public class StudyOnceCreateResponse {
 	private boolean canTalk;
 	private boolean canJoin;
 	private boolean isEnd;
+	private String openChatUrl;
 }

--- a/src/main/java/com/example/demo/dto/study/StudyOnceInfoResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceInfoResponse.java
@@ -19,4 +19,5 @@ public class StudyOnceInfoResponse {
 	private boolean canTalk;
 	private boolean canJoin;
 	private boolean isEnd;
+	private String openChatUrl;
 }

--- a/src/main/java/com/example/demo/dto/study/StudyOnceSearchResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceSearchResponse.java
@@ -20,5 +20,6 @@ public class StudyOnceSearchResponse {
 	private boolean canTalk;
 	private boolean canJoin;
 	private boolean isEnd;
+	private String openChatUrl;
 }
 

--- a/src/main/java/com/example/demo/dto/study/StudyOnceSearchResponse.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceSearchResponse.java
@@ -21,5 +21,6 @@ public class StudyOnceSearchResponse {
 	private boolean canJoin;
 	private boolean isEnd;
 	private String openChatUrl;
+	private boolean isAttendance;
 }
 

--- a/src/main/java/com/example/demo/dto/study/StudyOnceUpdateRequest.java
+++ b/src/main/java/com/example/demo/dto/study/StudyOnceUpdateRequest.java
@@ -25,4 +25,6 @@ public class StudyOnceUpdateRequest {
 	private int maxMemberCount;
 	@Nullable
 	private boolean canTalk;
+	@Nullable
+	private String openChatUrl;
 }

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -40,6 +40,7 @@ public enum ExceptionType {
 	STUDY_ONCE_PARENT_COMMENT_MODIFICATION_BLOCKED(FORBIDDEN, "답변이 존재하는 질문은 수정 할 수 없습니다."),
 	STUDY_ONCE_PARENT_COMMENT_REMOVAL_BLOCKED(FORBIDDEN, "답변이 존재하는 질문은 삭제 할 수 없습니다."),
 	STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE(BAD_REQUEST, "스터디 이름은 null, 빈 값, 혹은 공백만으로 이루어질 수 없습니다."),
+	STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE(BAD_REQUEST, "스터디의 오픈채팅방 URL은 null, 빈 값, 혹은 공백만으로 이루어질 수 없습니다."),
 	MEMBER_NOT_FOUND(NOT_FOUND, "없는 회원입니다."),
 	REVIEW_NOT_FOUND(NOT_FOUND, "없는 리뷰입니다."),
 	REVIEW_OVER_CONTENT_SIZE(BAD_REQUEST, "리뷰 글자수가 최대 글자수 이하여야 합니다."),

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -64,6 +64,7 @@ public class StudyOnceMapper {
 			.canTalk(saved.isAbleToTalk())
 			.canJoin(canJoin)
 			.isEnd(saved.isEnd())
+			.openChatUrl(saved.getOpenChatUrl())
 			.build();
 	}
 

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -45,6 +45,7 @@ public class StudyOnceMapper {
 			.nowMemberCount(0)
 			.isEnd(false)
 			.ableToTalk(studyOnceCreateRequest.isCanTalk())
+			.openChatUrl(studyOnceCreateRequest.getOpenChatUrl())
 			.cafe(cafe)
 			.leader(leader)
 			.build();
@@ -112,6 +113,7 @@ public class StudyOnceMapper {
 			.canTalk(saved.isAbleToTalk())
 			.canJoin(canJoin)
 			.isEnd(saved.isEnd())
+			.openChatUrl(saved.getOpenChatUrl())
 			.build();
 	}
 

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -68,7 +68,7 @@ public class StudyOnceMapper {
 			.build();
 	}
 
-	public StudyOnceSearchResponse toStudyOnceSearchResponse(StudyOnce saved, boolean canJoin) {
+	public StudyOnceSearchResponse toStudyOnceSearchResponse(StudyOnce saved, boolean canJoin, boolean isAttendance) {
 		return StudyOnceSearchResponse.builder()
 			.cafeId(saved.getCafe().getId())
 			.creatorId(saved.getLeader().getId())
@@ -83,6 +83,7 @@ public class StudyOnceMapper {
 			.canJoin(canJoin)
 			.isEnd(saved.isEnd())
 			.openChatUrl(saved.getOpenChatUrl())
+			.isAttendance(isAttendance)
 			.build();
 	}
 

--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -82,6 +82,7 @@ public class StudyOnceMapper {
 			.canTalk(saved.isAbleToTalk())
 			.canJoin(canJoin)
 			.isEnd(saved.isEnd())
+			.openChatUrl(saved.getOpenChatUrl())
 			.build();
 	}
 

--- a/src/main/java/com/example/demo/service/study/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceService.java
@@ -24,7 +24,7 @@ public interface StudyOnceService {
 
 	StudyOnceSearchResponse searchByStudyId(long studyId);
 
-	StudyOnceSearchResponse searchStudyOnceWithMemberParticipation(long studyId, long memberId);
+	StudyOnceSearchResponse searchStudyOnceWithMemberParticipation(long studyOnceId, long memberId);
 
 	UpdateAttendanceResponse updateAttendances(long leaderId, long studyOnceId,
 		UpdateAttendanceRequest request, LocalDateTime now);

--- a/src/main/java/com/example/demo/service/study/StudyOnceService.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceService.java
@@ -24,6 +24,8 @@ public interface StudyOnceService {
 
 	StudyOnceSearchResponse searchByStudyId(long studyId);
 
+	StudyOnceSearchResponse searchStudyOnceWithMemberParticipation(long studyId, long memberId);
+
 	UpdateAttendanceResponse updateAttendances(long leaderId, long studyOnceId,
 		UpdateAttendanceRequest request, LocalDateTime now);
 

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -112,8 +112,12 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 	}
 
 	@Override
-	public StudyOnceSearchResponse searchStudyOnceWithMemberParticipation(long studyId, long memberId) {
-		return null;
+	public StudyOnceSearchResponse searchStudyOnceWithMemberParticipation(long studyOnceId, long memberId) {
+		StudyOnce searched = studyOnceRepository.findById(studyOnceId)
+			.orElseThrow(() -> new CafegoryException(STUDY_ONCE_NOT_FOUND));
+		boolean canJoin = searched.canJoin(LocalDateTime.now());
+		boolean isAttendance = searched.isAttendance(findMemberById(memberId));
+		return studyOnceMapper.toStudyOnceSearchResponse(searched, canJoin, isAttendance);
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -208,6 +208,9 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		if (request.getStartDateTime() != null && request.getEndDateTime() != null) {
 			studyOnce.changeStudyOnceTime(request.getStartDateTime(), request.getEndDateTime());
 		}
+		if (request.getOpenChatUrl() != null) {
+			studyOnce.changeOpenChatUrl(request.getOpenChatUrl());
+		}
 		studyOnce.changeMaxMemberCount(request.getMaxMemberCount());
 		studyOnce.changeCanTalk(request.isCanTalk());
 	}

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -108,7 +108,12 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 		StudyOnce searched = studyOnceRepository.findById(studyId)
 			.orElseThrow(() -> new CafegoryException(STUDY_ONCE_NOT_FOUND));
 		boolean canJoin = searched.canJoin(LocalDateTime.now());
-		return studyOnceMapper.toStudyOnceSearchResponse(searched, canJoin);
+		return studyOnceMapper.toStudyOnceSearchResponse(searched, canJoin, false);
+	}
+
+	@Override
+	public StudyOnceSearchResponse searchStudyOnceWithMemberParticipation(long studyId, long memberId) {
+		return null;
 	}
 
 	@Override

--- a/src/test/java/com/example/demo/builder/TestStudyOnceBuilder.java
+++ b/src/test/java/com/example/demo/builder/TestStudyOnceBuilder.java
@@ -17,6 +17,7 @@ public class TestStudyOnceBuilder {
 	private int nowMemberCount = 0;
 	private boolean isEnd = false;
 	private boolean ableToTalk = true;
+	private String openChatUrl = "오픈채팅방 링크";
 	private Member leader;
 
 	public TestStudyOnceBuilder id(Long id) {
@@ -69,6 +70,11 @@ public class TestStudyOnceBuilder {
 		return this;
 	}
 
+	public TestStudyOnceBuilder openChatUrl(String openChatUrl) {
+		this.openChatUrl = openChatUrl;
+		return this;
+	}
+
 	public StudyOnce build() {
 		StudyOnce studyOnce = StudyOnce.builder()
 			.id(id)
@@ -81,6 +87,7 @@ public class TestStudyOnceBuilder {
 			.isEnd(isEnd)
 			.ableToTalk(ableToTalk)
 			.leader(leader)
+			.openChatUrl(openChatUrl)
 			.build();
 		return studyOnce;
 	}

--- a/src/test/java/com/example/demo/domain/study/StudyMemberTest.java
+++ b/src/test/java/com/example/demo/domain/study/StudyMemberTest.java
@@ -45,7 +45,7 @@ class StudyMemberTest {
 	void isConflict(TimeInterval timeInterval, boolean expected) {
 		LocalDateTime start = BASE_TIME.plusHours(4);
 		LocalDateTime end = BASE_TIME.plusHours(7);
-		StudyOnce studyOnce = makeStudyOnce(start, end);
+		StudyOnce studyOnce = makeStudyOnce("스터디 이름", start, end, "오픈채팅방 링크");
 		StudyMember studyMember = makeStudyMember(studyOnce);
 
 		boolean actual = studyMember.isConflictWith(timeInterval.start, timeInterval.end);
@@ -54,11 +54,13 @@ class StudyMemberTest {
 			.isEqualTo(expected);
 	}
 
-	private StudyOnce makeStudyOnce(LocalDateTime start, LocalDateTime end) {
+	private StudyOnce makeStudyOnce(String name, LocalDateTime start, LocalDateTime end, String openChatUrl) {
 		return StudyOnce.builder()
+			.name(name)
 			.startDateTime(start)
 			.endDateTime(end)
 			.leader(new TestMemberBuilder().build())
+			.openChatUrl(openChatUrl)
 			.build();
 	}
 

--- a/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
+++ b/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
@@ -335,4 +335,26 @@ class StudyOnceTest {
 		assertThat(doesOnlyLeaderExist).isFalse();
 	}
 
+	@Test
+	@DisplayName("멤버가 스터디에 참여했으면 true 반환")
+	void isAttendance() {
+		Member leader = Member.builder().id(LEADER_ID).build();
+		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
+
+		boolean isAttendance = studyOnce.isAttendance(member);
+		assertThat(isAttendance).isTrue();
+	}
+
+	@Test
+	@DisplayName("멤버가 스터디에 참여하지 않았으면 false 반환")
+	void isNotAttendance() {
+		Member leader = Member.builder().id(LEADER_ID).build();
+		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+
+		boolean isAttendance = studyOnce.isAttendance(member);
+		assertThat(isAttendance).isFalse();
+	}
 }

--- a/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
+++ b/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
@@ -84,9 +84,11 @@ class StudyOnceTest {
 	@DisplayName("참여 가능 여부 결정 테스트")
 	void canJoin(LocalDateTime base, LocalDateTime start, boolean expected) {
 		StudyOnce studyOnce = StudyOnce.builder()
+			.name("스터디 이름")
 			.startDateTime(start)
 			.endDateTime(start.plusHours(4))
 			.leader(Member.builder().build())
+			.openChatUrl("오픈채팅방 링크")
 			.build();
 
 		boolean canJoin = studyOnce.canJoin(base);
@@ -102,9 +104,11 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 
 		StudyOnce studyOnce = StudyOnce.builder()
+			.name("스터디 이름")
 			.startDateTime(start)
 			.endDateTime(start.plusHours(4))
 			.leader(leader)
+			.openChatUrl("오픈채팅방 링크")
 			.build();
 
 		StudyOnce study = studyOnce.getStudyMembers().get(0).getStudy();
@@ -119,7 +123,7 @@ class StudyOnceTest {
 	void tryJoin() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
 		List<Member> collect = studyOnce.getStudyMembers()
@@ -133,16 +137,20 @@ class StudyOnceTest {
 
 	private static Member makeMemberWithStudyOnce(LocalDateTime start, LocalDateTime end) {
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyMember studyMember = new StudyMember(member, makeStudy(member, start, end));
+		StudyMember studyMember = new StudyMember(member, makeStudy(member, "스터디 이름", start, end, "오픈채팅방 링크"));
 		member.setStudyMembers(new ArrayList<>(List.of(studyMember)));
 		return member;
 	}
 
-	private static StudyOnce makeStudy(Member leader, LocalDateTime start, LocalDateTime end) {
+	private static StudyOnce makeStudy(Member leader, String studyName, LocalDateTime start, LocalDateTime end,
+		String openChatUrl) {
 		return StudyOnce.builder()
+			.name(studyName)
 			.startDateTime(start)
 			.endDateTime(end)
 			.leader(leader)
+			.name(studyName)
+			.openChatUrl(openChatUrl)
 			.build();
 	}
 
@@ -152,7 +160,7 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
 
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		Assertions.assertThatThrownBy(
 				() -> studyOnce.tryJoin(member, NOW.plusHours(3).plusSeconds(1)))
@@ -166,7 +174,7 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
 
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(5), NOW.plusHours(9));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(5), NOW.plusHours(9), "오픈채팅방 링크");
 
 		Assertions.assertThatThrownBy(() -> studyOnce.tryJoin(member, NOW))
 			.isInstanceOf(CafegoryException.class)
@@ -178,7 +186,7 @@ class StudyOnceTest {
 	void tryJoinFailByDuplicate() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		studyOnce.tryJoin(member, NOW);
 
@@ -193,7 +201,7 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
 
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		studyOnce.tryJoin(member, NOW);
 
 		LocalDateTime validRequestTime = NOW.plusHours(3).minusSeconds(1);
@@ -205,7 +213,7 @@ class StudyOnceTest {
 	void tryQuitFailByTimeOver() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		studyOnce.tryJoin(member, NOW);
 		Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW.plusHours(3).plusSeconds(1)))
@@ -218,7 +226,7 @@ class StudyOnceTest {
 	void tryQuitFailByNotJoin() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW))
 			.isInstanceOf(CafegoryException.class)
@@ -229,7 +237,7 @@ class StudyOnceTest {
 	@DisplayName("스터디 이름 변경, null 검증")
 	void validate_null_by_changeName() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeName(null))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE.getErrorMessage());
@@ -240,17 +248,38 @@ class StudyOnceTest {
 	@DisplayName("스터디 이름 변경, 빈값, 공백문자 검증")
 	void validate_empty_or_whitespace_by_changeName(String value) {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeName(value))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE.getErrorMessage());
 	}
 
 	@Test
+	@DisplayName("스터디 오픈채팅방 url 변경, null 검증")
+	void validate_null_by_changeOpenChatUrl() {
+		Member leader = Member.builder().id(LEADER_ID).build();
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		assertThatThrownBy(() -> studyOnce.changeOpenChatUrl(null))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE.getErrorMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"", " "})
+	@DisplayName("스터디 오픈채팅방 url 변경, 빈값, 공백문자 검증")
+	void validate_empty_or_whitespace_by_changeOpenChatUrl(String value) {
+		Member leader = Member.builder().id(LEADER_ID).build();
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		assertThatThrownBy(() -> studyOnce.changeOpenChatUrl(value))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE.getErrorMessage());
+	}
+
+	@Test
 	@DisplayName("최대 참여인원 5명이다. 정상동작")
 	void changeMaxMemberCount() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertDoesNotThrow(() -> studyOnce.changeMaxMemberCount(5));
 	}
 
@@ -258,7 +287,7 @@ class StudyOnceTest {
 	@DisplayName("최대 참여인원은 5명이다. 6명이면 예외가 터진다.")
 	void validate_maxMemberCount_by_changeMaxMemberCount() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeMaxMemberCount(6))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_LIMIT_MEMBER_CAPACITY.getErrorMessage());
@@ -269,11 +298,13 @@ class StudyOnceTest {
 	void validate_maxOrNowMemberCount_by_changeMaxMemberCount() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		StudyOnce studyOnce = StudyOnce.builder()
+			.name("스터디 이름")
 			.startDateTime(NOW.plusHours(4))
 			.endDateTime(NOW.plusHours(8))
 			.maxMemberCount(4)
 			.nowMemberCount(1)
 			.leader(leader)
+			.openChatUrl("오픈채팅방 링크")
 			.build();
 
 		assertThatThrownBy(() -> studyOnce.changeMaxMemberCount(0))
@@ -285,7 +316,7 @@ class StudyOnceTest {
 	@DisplayName("카공에 참여인원이 카공장만 있으면 true 반환")
 	void doesOnlyLeaderExist_then_true() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		boolean doesOnlyLeaderExist = studyOnce.doesOnlyLeaderExist();
 		assertThat(doesOnlyLeaderExist).isTrue();
@@ -296,7 +327,7 @@ class StudyOnceTest {
 	void doesOnlyLeaderExist_then_false() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8));
+		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
 

--- a/src/test/java/com/example/demo/repository/study/InMemoryStudyOnceRepository.java
+++ b/src/test/java/com/example/demo/repository/study/InMemoryStudyOnceRepository.java
@@ -38,6 +38,7 @@ public class InMemoryStudyOnceRepository implements StudyOnceRepository {
 			.ableToTalk(studyOnce.isAbleToTalk())
 			.cafe(studyOnce.getCafe())
 			.isEnd(studyOnce.isEnd())
+			.openChatUrl(studyOnce.getOpenChatUrl())
 			.build();
 	}
 

--- a/src/test/java/com/example/demo/service/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/profile/ProfileServiceImplTest.java
@@ -85,7 +85,7 @@ class ProfileServiceImplTest extends ServiceTest {
 
 	private static StudyOnceCreateRequest makeStudyOnceCreateRequest(LocalDateTime start, LocalDateTime end,
 		long cafeId) {
-		return new StudyOnceCreateRequest(cafeId, "테스트 카페", start, end, 4, true);
+		return new StudyOnceCreateRequest(cafeId, "테스트 카페", start, end, 4, true, "오픈채팅방 링크");
 	}
 
 	@Test

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -148,6 +148,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 			.canTalk(studyOnceCreateRequest.isCanTalk())
 			.canJoin(canJoin)
 			.isEnd(isEnd)
+			.openChatUrl(studyOnceCreateRequest.getOpenChatUrl())
 			.build();
 	}
 
@@ -585,7 +586,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long studyOnceId = searchResponse.getStudyOnceId();
 		long cafeId2 = cafePersistHelper.persistDefaultCafe().getId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId2, "변경된카공이름", start.plusHours(5),
-			start.plusHours(6), 5, false);
+			start.plusHours(6), 5, false, "오픈채팅방 링크");
 
 		studyOnceService.updateStudyOnce(leaderId, studyOnceId, request, LocalDateTime.now());
 		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).get();
@@ -596,7 +597,8 @@ class StudyOnceServiceImplTest extends ServiceTest {
 			() -> assertThat(studyOnce.getStartDateTime()).isEqualTo(request.getStartDateTime()),
 			() -> assertThat(studyOnce.getEndDateTime()).isEqualTo(request.getEndDateTime()),
 			() -> assertThat(studyOnce.getMaxMemberCount()).isEqualTo(request.getMaxMemberCount()),
-			() -> assertThat(studyOnce.isAbleToTalk()).isEqualTo(request.isCanTalk())
+			() -> assertThat(studyOnce.isAbleToTalk()).isEqualTo(request.isCanTalk()),
+			() -> assertThat(studyOnce.getOpenChatUrl()).isEqualTo(request.getOpenChatUrl())
 		);
 	}
 
@@ -611,7 +613,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(999L, "변경된카공이름", start.plusHours(5),
-			start.plusHours(6), 5, false);
+			start.plusHours(6), 5, false, "오픈채팅방 링크");
 
 		assertThatThrownBy(() -> studyOnceService.updateStudyOnce(leaderId, studyOnceId, request, LocalDateTime.now()))
 			.isInstanceOf(CafegoryException.class)
@@ -629,7 +631,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId1, "변경된카공이름", start.plusHours(5),
-			start.plusHours(6), 5, false);
+			start.plusHours(6), 5, false, "오픈채팅방 링크");
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 
 		assertThatThrownBy(
@@ -654,7 +656,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		syncStudyOnceRepositoryAndStudyMemberRepository();
 
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId2, null, null,
-			null, 5, false);
+			null, 5, false, null);
 		studyOnceService.updateStudyOncePartially(leaderId, studyOnceId, request, LocalDateTime.now());
 		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).get();
 
@@ -664,7 +666,8 @@ class StudyOnceServiceImplTest extends ServiceTest {
 			() -> assertThat(studyOnce.getStartDateTime()).isEqualTo(searchResponse.getStartDateTime()),
 			() -> assertThat(studyOnce.getEndDateTime()).isEqualTo(searchResponse.getEndDateTime()),
 			() -> assertThat(studyOnce.getMaxMemberCount()).isEqualTo(request.getMaxMemberCount()),
-			() -> assertThat(studyOnce.isAbleToTalk()).isEqualTo(searchResponse.isCanTalk())
+			() -> assertThat(studyOnce.isAbleToTalk()).isEqualTo(searchResponse.isCanTalk()),
+			() -> assertThat(studyOnce.getOpenChatUrl()).isEqualTo(searchResponse.getOpenChatUrl())
 		);
 	}
 
@@ -684,7 +687,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		syncStudyOnceRepositoryAndStudyMemberRepository();
 
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId2, "변경된카공이름", start.plusHours(5),
-			start.plusHours(6), 5, false);
+			start.plusHours(6), 5, false, "오픈채팅방 링크");
 		studyOnceService.updateStudyOncePartially(leaderId, studyOnceId, request, LocalDateTime.now());
 		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).get();
 
@@ -694,7 +697,8 @@ class StudyOnceServiceImplTest extends ServiceTest {
 			() -> assertThat(studyOnce.getStartDateTime()).isEqualTo(searchResponse.getStartDateTime()),
 			() -> assertThat(studyOnce.getEndDateTime()).isEqualTo(searchResponse.getEndDateTime()),
 			() -> assertThat(studyOnce.getMaxMemberCount()).isEqualTo(request.getMaxMemberCount()),
-			() -> assertThat(studyOnce.isAbleToTalk()).isEqualTo(searchResponse.isCanTalk())
+			() -> assertThat(studyOnce.isAbleToTalk()).isEqualTo(searchResponse.isCanTalk()),
+			() -> assertThat(studyOnce.getOpenChatUrl()).isEqualTo(searchResponse.getOpenChatUrl())
 		);
 	}
 
@@ -709,7 +713,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
 		long studyOnceId = searchResponse.getStudyOnceId();
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId1, null, null,
-			null, 5, true);
+			null, 5, true, null);
 		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 
 		assertThatThrownBy(

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -90,7 +90,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 
 	private StudyOnceCreateRequest makeStudyOnceCreateRequest(LocalDateTime start, LocalDateTime end,
 		long cafeId) {
-		return new StudyOnceCreateRequest(cafeId, "테스트 스터디", start, end, 4, true);
+		return new StudyOnceCreateRequest(cafeId, "테스트 스터디", start, end, 4, true, "오픈채팅방 링크");
 	}
 
 	private void syncStudyOnceRepositoryAndStudyMemberRepository() {

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -117,8 +117,24 @@ class StudyOnceServiceImplTest extends ServiceTest {
 	}
 
 	@Test
+	@DisplayName("회원이 아닐떄 카공을 조회하면 카공의 참석여부는 false를 반환한다.")
+	void searchByStudyId_when_not_member() {
+		LocalDateTime start = LocalDateTime.now().plusHours(3).plusMinutes(1);
+		LocalDateTime end = start.plusHours(1);
+		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
+		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
+
+		StudyOnceCreateResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		StudyOnceSearchResponse studyOnceSearchResponse = studyOnceService.searchByStudyId(result.getStudyOnceId());
+
+		assertThat(studyOnceSearchResponse.isAttendance()).isFalse();
+	}
+
+	@Test
 	@DisplayName("정상 생성 테스트")
 	void create() {
+
 		LocalDateTime start = LocalDateTime.now().plusHours(3).plusMinutes(1);
 		LocalDateTime end = start.plusHours(1);
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -124,11 +124,49 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
 		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
 		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
-
 		StudyOnceCreateResponse result = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+
 		StudyOnceSearchResponse studyOnceSearchResponse = studyOnceService.searchByStudyId(result.getStudyOnceId());
 
 		assertThat(studyOnceSearchResponse.isAttendance()).isFalse();
+	}
+
+	@Test
+	@DisplayName("회원이 카공을 조회할때 카공 멤버라면 참석여부는 true를 반환한다.")
+	void searchStudyOnceWithMemberParticipation_when_takes_attendance() {
+		LocalDateTime start = LocalDateTime.now().plusHours(4);
+		LocalDateTime end = start.plusHours(4);
+		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
+		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
+		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		long studyOnceId = searchResponse.getStudyOnceId();
+		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+		studyOnceService.tryJoin(memberId, studyOnceId);
+		syncStudyOnceRepositoryAndStudyMemberRepository();
+
+		StudyOnceSearchResponse response = studyOnceService.searchStudyOnceWithMemberParticipation(
+			studyOnceId, memberId);
+
+		assertThat(response.isAttendance()).isTrue();
+	}
+
+	@Test
+	@DisplayName("회원이 카공을 조회할때 카공 멤버가 아니라면 참석여부는 false를 반환한다.")
+	void searchStudyOnceWithMemberParticipation_when_not_take_attendance() {
+		LocalDateTime start = LocalDateTime.now().plusHours(4);
+		LocalDateTime end = start.plusHours(4);
+		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
+		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
+		long leaderId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+		StudyOnceCreateResponse searchResponse = studyOnceService.createStudy(leaderId, studyOnceCreateRequest);
+		long studyOnceId = searchResponse.getStudyOnceId();
+		long memberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+
+		StudyOnceSearchResponse response = studyOnceService.searchStudyOnceWithMemberParticipation(
+			studyOnceId, memberId);
+
+		assertThat(response.isAttendance()).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항

- 카공에 오픈채팅방url 추가
- 카공 모집글 생성 기능에 오픈채팅방 url 추가
- 카공 모집글 수정에 오픈채팅방 url 추가
- 카공 모집글 조회에 조회한 회원이 그 카공에 참여했는지 알 수 있는 정보 추가

close #82
