### PR TITLE
[BUILD SUCCESS] 카공 nowMemberCount 0으로 나오는 오류 수정

### DIFF
--- a/src/main/java/com/example/demo/domain/study/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/study/StudyOnce.java
@@ -88,6 +88,7 @@ public class StudyOnce {
 		validateConflictJoin(leader);
 		studyMembers = new ArrayList<>();
 		studyMembers.add(new StudyMember(leader, this));
+		this.nowMemberCount = 1;
 	}
 
 	private static void validateStartDateTime(LocalDateTime startDateTime) {
@@ -124,9 +125,17 @@ public class StudyOnce {
 		validateJoinRequestTime(requestTime);
 		validateDuplicateJoin(memberThatExpectedToJoin);
 		validateConflictJoin(memberThatExpectedToJoin);
+		validateStudyMemberIsFull();
 		StudyMember studyMember = new StudyMember(memberThatExpectedToJoin, this);
 		studyMembers.add(studyMember);
 		memberThatExpectedToJoin.addStudyMember(studyMember);
+		nowMemberCount = studyMembers.size();
+	}
+
+	private void validateStudyMemberIsFull() {
+		if (nowMemberCount == maxMemberCount) {
+			throw new CafegoryException(STUDY_ONCE_FULL);
+		}
 	}
 
 	private void validateConflictJoin(Member memberThatExpectedToJoin) {

--- a/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
+++ b/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
@@ -123,7 +123,7 @@ class StudyOnceTest {
 	void tryJoin() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
 		List<Member> collect = studyOnce.getStudyMembers()
@@ -137,19 +137,18 @@ class StudyOnceTest {
 
 	private static Member makeMemberWithStudyOnce(LocalDateTime start, LocalDateTime end) {
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyMember studyMember = new StudyMember(member, makeStudy(member, "스터디 이름", start, end, "오픈채팅방 링크"));
+		StudyMember studyMember = new StudyMember(member, makeStudy(member, start, end, "오픈채팅방 링크"));
 		member.setStudyMembers(new ArrayList<>(List.of(studyMember)));
 		return member;
 	}
 
-	private static StudyOnce makeStudy(Member leader, String studyName, LocalDateTime start, LocalDateTime end,
+	private static StudyOnce makeStudy(Member leader, LocalDateTime start, LocalDateTime end,
 		String openChatUrl) {
 		return StudyOnce.builder()
-			.name(studyName)
 			.startDateTime(start)
 			.endDateTime(end)
 			.leader(leader)
-			.name(studyName)
+			.name("스터디 이름")
 			.openChatUrl(openChatUrl)
 			.maxMemberCount(5)
 			.build();
@@ -161,7 +160,7 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
 
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		Assertions.assertThatThrownBy(
 				() -> studyOnce.tryJoin(member, NOW.plusHours(3).plusSeconds(1)))
@@ -175,7 +174,7 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
 
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(5), NOW.plusHours(9), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(5), NOW.plusHours(9), "오픈채팅방 링크");
 
 		Assertions.assertThatThrownBy(() -> studyOnce.tryJoin(member, NOW))
 			.isInstanceOf(CafegoryException.class)
@@ -187,7 +186,7 @@ class StudyOnceTest {
 	void tryJoinFailByDuplicate() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		studyOnce.tryJoin(member, NOW);
 
@@ -201,7 +200,7 @@ class StudyOnceTest {
 	void tryJoinFailByFullMember() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(7), "오픈채팅링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(7), "오픈채팅링크");
 		for (int index = 0; index < 4; index++) {
 			Member member = Member.builder().id(MEMBER_ID + index).build();
 			studyOnce.tryJoin(member, NOW.plusSeconds(index));
@@ -218,7 +217,7 @@ class StudyOnceTest {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
 
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		studyOnce.tryJoin(member, NOW);
 
 		LocalDateTime validRequestTime = NOW.plusHours(3).minusSeconds(1);
@@ -230,7 +229,7 @@ class StudyOnceTest {
 	void tryQuitFailByTimeOver() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		studyOnce.tryJoin(member, NOW);
 		Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW.plusHours(3).plusSeconds(1)))
@@ -243,7 +242,7 @@ class StudyOnceTest {
 	void tryQuitFailByNotJoin() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		Assertions.assertThatThrownBy(
 				() -> studyOnce.tryQuit(member, NOW))
 			.isInstanceOf(CafegoryException.class)
@@ -254,7 +253,7 @@ class StudyOnceTest {
 	@DisplayName("스터디 이름 변경, null 검증")
 	void validate_null_by_changeName() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeName(null))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE.getErrorMessage());
@@ -265,7 +264,7 @@ class StudyOnceTest {
 	@DisplayName("스터디 이름 변경, 빈값, 공백문자 검증")
 	void validate_empty_or_whitespace_by_changeName(String value) {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeName(value))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_NAME_EMPTY_OR_WHITESPACE.getErrorMessage());
@@ -275,7 +274,7 @@ class StudyOnceTest {
 	@DisplayName("스터디 오픈채팅방 url 변경, null 검증")
 	void validate_null_by_changeOpenChatUrl() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeOpenChatUrl(null))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE.getErrorMessage());
@@ -286,7 +285,7 @@ class StudyOnceTest {
 	@DisplayName("스터디 오픈채팅방 url 변경, 빈값, 공백문자 검증")
 	void validate_empty_or_whitespace_by_changeOpenChatUrl(String value) {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeOpenChatUrl(value))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_OPEN_CHAT_URL_EMPTY_OR_WHITESPACE.getErrorMessage());
@@ -296,7 +295,7 @@ class StudyOnceTest {
 	@DisplayName("최대 참여인원 5명이다. 정상동작")
 	void changeMaxMemberCount() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertDoesNotThrow(() -> studyOnce.changeMaxMemberCount(5));
 	}
 
@@ -304,7 +303,7 @@ class StudyOnceTest {
 	@DisplayName("최대 참여인원은 5명이다. 6명이면 예외가 터진다.")
 	void validate_maxMemberCount_by_changeMaxMemberCount() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		assertThatThrownBy(() -> studyOnce.changeMaxMemberCount(6))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_LIMIT_MEMBER_CAPACITY.getErrorMessage());
@@ -333,7 +332,7 @@ class StudyOnceTest {
 	@DisplayName("카공에 참여인원이 카공장만 있으면 true 반환")
 	void doesOnlyLeaderExist_then_true() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		boolean doesOnlyLeaderExist = studyOnce.doesOnlyLeaderExist();
 		assertThat(doesOnlyLeaderExist).isTrue();
@@ -344,7 +343,7 @@ class StudyOnceTest {
 	void doesOnlyLeaderExist_then_false() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
 
@@ -357,7 +356,7 @@ class StudyOnceTest {
 	void isAttendance() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 		studyOnce.tryJoin(member, NOW.plusHours(3).minusSeconds(1));
 
 		boolean isAttendance = studyOnce.isAttendance(member);
@@ -369,7 +368,7 @@ class StudyOnceTest {
 	void isNotAttendance() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = makeMemberWithStudyOnce(NOW.plusHours(9), NOW.plusHours(13));
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
 
 		boolean isAttendance = studyOnce.isAttendance(member);
 		assertThat(isAttendance).isFalse();
@@ -379,7 +378,7 @@ class StudyOnceTest {
 	@DisplayName("카공 생성시 카공장이 인원에 잘 반영되는지 확인")
 	void validateNowMemberCountWhenCreate() {
 		Member leader = Member.builder().id(LEADER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(7), "오픈채팅링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(7), "오픈채팅링크");
 
 		int nowMemberCount = studyOnce.getNowMemberCount();
 
@@ -392,7 +391,7 @@ class StudyOnceTest {
 	void validateNowMemberCountWhenJoin() {
 		Member leader = Member.builder().id(LEADER_ID).build();
 		Member member = Member.builder().id(MEMBER_ID).build();
-		StudyOnce studyOnce = makeStudy(leader, "스터디 이름", NOW.plusHours(4), NOW.plusHours(7), "오픈채팅링크");
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(7), "오픈채팅링크");
 
 		studyOnce.tryJoin(member, NOW.plusHours(3));
 		int nowMemberCount = studyOnce.getNowMemberCount();

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -643,7 +643,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 			start.plusHours(6), 5, false, "오픈채팅방 링크");
 
 		studyOnceService.updateStudyOnce(leaderId, studyOnceId, request, LocalDateTime.now());
-		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).get();
+		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).orElseThrow();
 
 		assertAll(
 			() -> assertThat(studyOnce.getName()).isEqualTo(request.getName()),
@@ -712,7 +712,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId2, null, null,
 			null, 5, false, null);
 		studyOnceService.updateStudyOncePartially(leaderId, studyOnceId, request, LocalDateTime.now());
-		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).get();
+		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).orElseThrow();
 
 		assertAll(
 			() -> assertThat(studyOnce.getName()).isEqualTo(searchResponse.getName()),
@@ -743,7 +743,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 		StudyOnceUpdateRequest request = new StudyOnceUpdateRequest(cafeId2, "변경된카공이름", start.plusHours(5),
 			start.plusHours(6), 5, false, "오픈채팅방 링크");
 		studyOnceService.updateStudyOncePartially(leaderId, studyOnceId, request, LocalDateTime.now());
-		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).get();
+		StudyOnce studyOnce = studyOnceRepository.findById(studyOnceId).orElseThrow();
 
 		assertAll(
 			() -> assertThat(studyOnce.getName()).isEqualTo(searchResponse.getName()),

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -187,7 +187,7 @@ class StudyOnceServiceImplTest extends ServiceTest {
 
 	private static StudyOnceCreateResponse makeExpectedStudyOnceCreateResult(long cafeId,
 		StudyOnceCreateRequest studyOnceCreateRequest, StudyOnceCreateResponse result) {
-		int nowMemberCount = 0;
+		int nowMemberCount = 1;
 		boolean canJoin = true;
 		boolean isEnd = false;
 		return StudyOnceCreateResponse.builder()


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항
카공 생성 및 참여 시 현재 인원에 반영하도록 수정

카공 참여 시 인원 제한 검증 추가
# 확인 방법 (스크린샷 포함)
