### PR TITLE
[BUILD SUCCESS] 카페 리뷰 목록 조회시 페이징되기전 전체 리뷰 개수 추가 및 카페 정보 조회시 리뷰 데이터 삭제, 전체 리뷰 개수 추가

### DIFF
--- a/src/main/java/com/example/demo/dto/PagedResponse.java
+++ b/src/main/java/com/example/demo/dto/PagedResponse.java
@@ -9,10 +9,11 @@ public class PagedResponse<T> {
 	private final int nowPage;
 	private final int maxPage;
 	private final int pageSize;
+	private final long totalElements;
 	private final List<T> list;
 
 	public static <T> PagedResponse<T> createWithFirstPageAsOne(int nowPage, int maxPage, int pageSize,
-		List<T> results) {
-		return new PagedResponse<>(nowPage + 1, maxPage, pageSize, results);
+		long totalElements, List<T> results) {
+		return new PagedResponse<>(nowPage + 1, maxPage, pageSize, totalElements, results);
 	}
 }

--- a/src/main/java/com/example/demo/dto/cafe/CafeSearchResponse.java
+++ b/src/main/java/com/example/demo/dto/cafe/CafeSearchResponse.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class CafeSearchResponse {
 
 	private final CafeSearchBasicInfoResponse basicInfo;
-	private final List<CafeSearchReviewResponse> review;
+	private final long totalElementsOfReview;
 	private final List<CafeSearchStudyOnceResponse> meetings;
 	private final List<CanMakeStudyOnceResponse> canMakeMeeting;
 }

--- a/src/main/java/com/example/demo/mapper/CafeMapper.java
+++ b/src/main/java/com/example/demo/mapper/CafeMapper.java
@@ -101,8 +101,8 @@ public class CafeMapper {
 					cafeSearchSnsResponses,
 					openChecker)
 			)
-			.review(
-				cafeSearchReviewResponses
+			.totalElementsOfReview(
+				findCafe.getReviews().size()
 			)
 			.meetings(
 				cafeSearchStudyOnceResponses
@@ -128,8 +128,8 @@ public class CafeMapper {
 					snsResponses,
 					openChecker)
 			)
-			.review(
-				reviewResponses
+			.totalElementsOfReview(
+				findCafe.getReviews().size()
 			)
 			.meetings(
 				Collections.emptyList()

--- a/src/main/java/com/example/demo/service/cafe/CafeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/cafe/CafeServiceImpl.java
@@ -101,6 +101,7 @@ public class CafeServiceImpl implements CafeService {
 			pagedCafes.getNumber(),
 			pagedCafes.getTotalPages(),
 			pagedCafes.getNumberOfElements(),
+			pagedCafes.getTotalElements(),
 			cafeSearchListResponse
 		);
 	}

--- a/src/main/java/com/example/demo/service/review/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/review/ReviewQueryServiceImpl.java
@@ -63,6 +63,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 			pagedReviews.getNumber(),
 			pagedReviews.getTotalPages(),
 			pagedReviews.getNumberOfElements(),
+			pagedReviews.getTotalElements(),
 			reviewSearchListResponse
 		);
 	}

--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -93,7 +93,8 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 			.map(studyOnce -> studyOnceMapper.toStudyOnceSearchListResponse(studyOnce,
 				studyOnce.canJoin(LocalDateTime.now())))
 			.collect(Collectors.toList());
-		return new PagedResponse<>(studyOnceSearchRequest.getPage(), maxPage, searchResults.size(), searchResults);
+		return new PagedResponse<>(studyOnceSearchRequest.getPage(), maxPage, searchResults.size(), totalCount,
+			searchResults);
 	}
 
 	private int calculateMaxPage(int totalCount, int sizePerPage) {


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항
PagedResponse 객체에 totalElements 필드 추가
- 페이지네이션을 하는 api에 도메인의 전체 개수가 들어감
- 카페 목록 조회, 카페 리뷰 목록 조회, 카공 모집글 목록 조회를 조회할때 api 스펙이 변경됨
- 카페 정보 조회 api 는 PagedResponse를 사용하지 않지만, 전체 리뷰 개수가 필요하므로 api 스펙이 변경됨

close #95 