### PR TITLE
[BUILD SUCCESS] 카공 참여취소후 카공의 참여 인원수가 반영되도록 수정

### DIFF
--- a/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
+++ b/src/main/java/com/example/demo/mapper/StudyOnceMapper.java
@@ -75,7 +75,7 @@ public class StudyOnceMapper {
 			.startDateTime(saved.getStartDateTime())
 			.endDateTime(saved.getEndDateTime())
 			.maxMemberCount(saved.getMaxMemberCount())
-			.nowMemberCount(saved.getNowMemberCount())
+			.nowMemberCount(saved.getStudyMembers().size())
 			.canTalk(saved.isAbleToTalk())
 			.canJoin(canJoin)
 			.isEnd(saved.isEnd())

--- a/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
+++ b/src/test/java/com/example/demo/service/study/StudyOnceServiceImplTest.java
@@ -391,6 +391,23 @@ class StudyOnceServiceImplTest extends ServiceTest {
 	}
 
 	@Test
+	@DisplayName("카공 참여 취소를 하면 카공의 모집 인원수가 줄어든다.")
+	void tryQuit_then_studyOnce_nowMemberCount_is_reduced() {
+		LocalDateTime start = LocalDateTime.now().plusHours(4);
+		LocalDateTime end = start.plusHours(4);
+		long firstMemberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+		long secondMemberId = memberPersistHelper.persistDefaultMember(THUMBNAIL_IMAGE).getId();
+		long cafeId = cafePersistHelper.persistDefaultCafe().getId();
+		StudyOnceCreateRequest studyOnceCreateRequest = makeStudyOnceCreateRequest(start, end, cafeId);
+		StudyOnceCreateResponse study = studyOnceService.createStudy(firstMemberId, studyOnceCreateRequest);
+		studyOnceService.tryJoin(secondMemberId, study.getStudyOnceId());
+
+		studyOnceService.tryQuit(secondMemberId, study.getStudyOnceId());
+
+		assertThat(study.getNowMemberCount()).isEqualTo(1);
+	}
+
+	@Test
 	@DisplayName("참여중인 카공이 아니라 참여 취소 실패")
 	void tryQuitFailCauseNotJoin() {
 		LocalDateTime start = LocalDateTime.now().plusHours(4);


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항

- StudyOnceMapper 클래스의 메서드 로직 수정
- 카공 참여 인원수 테스트 케이스 작성

close #97