### PR TITLE
[BUILD SUCCESS] fix: 카공 시간 수정시 카페 영업시간 이후로 수정이 되는 오류 해결

### DIFF
--- a/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
+++ b/src/main/java/com/example/demo/service/study/StudyOnceServiceImpl.java
@@ -229,6 +229,9 @@ public class StudyOnceServiceImpl implements StudyOnceService {
 			studyOnce.changeName(request.getName());
 		}
 		if (request.getStartDateTime() != null && request.getEndDateTime() != null) {
+			Cafe cafe = studyOnce.getCafe();
+			validateBetweenBusinessHour(request.getStartDateTime().toLocalTime(),
+				request.getEndDateTime().toLocalTime(), cafe.findBusinessHour(now.getDayOfWeek()));
 			studyOnce.changeStudyOnceTime(request.getStartDateTime(), request.getEndDateTime());
 		}
 		if (request.getOpenChatUrl() != null) {


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항
- 카공 시간 수정시 카페 영업시간 사이에 수정이 가능하도록 로직 수정

close #103 
