### PR TITLE
[BUILD SUCCESS] 카공 생성, 수정할때 최대인원 0명이 가능한 오류 수정

### DIFF
--- a/src/main/java/com/example/demo/domain/study/StudyOnce.java
+++ b/src/main/java/com/example/demo/domain/study/StudyOnce.java
@@ -40,6 +40,7 @@ import lombok.NoArgsConstructor;
 public class StudyOnce {
 
 	private static final int LIMIT_MEMBER_CAPACITY = 5;
+	private static final int MIN_LIMIT_MEMBER_CAPACITY = 1;
 
 	@Id
 	@GeneratedValue
@@ -110,7 +111,7 @@ public class StudyOnce {
 	}
 
 	private void validateMaxMemberCount(int maxMemberCount) {
-		if (maxMemberCount > LIMIT_MEMBER_CAPACITY) {
+		if (maxMemberCount > LIMIT_MEMBER_CAPACITY || maxMemberCount < MIN_LIMIT_MEMBER_CAPACITY) {
 			throw new CafegoryException(STUDY_ONCE_LIMIT_MEMBER_CAPACITY);
 		}
 	}

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -19,7 +19,7 @@ public enum ExceptionType {
 	STUDY_ONCE_SHORT_DURATION(BAD_REQUEST, "카공 시간은 1시간 이상이어야 합니다."),
 	STUDY_ONCE_LONG_DURATION(BAD_REQUEST, "카공 시간은 5시간 미만이어야 합니다."),
 	STUDY_ONCE_TOO_MUCH_STUDY_IN_CAFE(BAD_REQUEST, "이 카페에 이 인원의 카공을 더이상 생성할 수 없습니다."),
-	STUDY_ONCE_LIMIT_MEMBER_CAPACITY(BAD_REQUEST, "카공 최대 참여 인원 수는 5명 입니다."),
+	STUDY_ONCE_LIMIT_MEMBER_CAPACITY(BAD_REQUEST, "카공 최대 참여 인원 수는 1명 이상 5명 이하 입니다."),
 	STUDY_ONCE_CANNOT_REDUCE_BELOW_CURRENT(BAD_REQUEST, "카공 최대 참여 인원 수는 현재 참여 신청중인 인원보다 적을 수 없습니다."),
 	STUDY_ONCE_CONFLICT_TIME(CONFLICT, "해당 시간에 참여중인 카공이 이미 있습니다."),
 	STUDY_ONCE_DUPLICATE(CONFLICT, "이미 참여중인 카공입니다."),

--- a/src/test/java/com/example/demo/domain/study/StudyMemberTest.java
+++ b/src/test/java/com/example/demo/domain/study/StudyMemberTest.java
@@ -61,6 +61,7 @@ class StudyMemberTest {
 			.endDateTime(end)
 			.leader(new TestMemberBuilder().build())
 			.openChatUrl(openChatUrl)
+			.maxMemberCount(5)
 			.build();
 	}
 

--- a/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
+++ b/src/test/java/com/example/demo/domain/study/StudyOnceTest.java
@@ -89,6 +89,7 @@ class StudyOnceTest {
 			.endDateTime(start.plusHours(4))
 			.leader(Member.builder().build())
 			.openChatUrl("오픈채팅방 링크")
+			.maxMemberCount(5)
 			.build();
 
 		boolean canJoin = studyOnce.canJoin(base);
@@ -109,6 +110,7 @@ class StudyOnceTest {
 			.endDateTime(start.plusHours(4))
 			.leader(leader)
 			.openChatUrl("오픈채팅방 링크")
+			.maxMemberCount(5)
 			.build();
 
 		StudyOnce study = studyOnce.getStudyMembers().get(0).getStudy();
@@ -310,9 +312,28 @@ class StudyOnceTest {
 	}
 
 	@Test
+	@DisplayName("최소 참여인원은 1명이다. 0명이면 예외가 터진다.")
+	void validate_MemberCount_by_changeMaxMemberCount_then_exception() {
+		Member leader = Member.builder().id(LEADER_ID).build();
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		assertThatThrownBy(() -> studyOnce.changeMaxMemberCount(0))
+			.isInstanceOf(CafegoryException.class)
+			.hasMessage(STUDY_ONCE_LIMIT_MEMBER_CAPACITY.getErrorMessage());
+	}
+
+	@Test
+	@DisplayName("최소 참여인원은 1명이다.")
+	void changeMaxMemberCount_by_one() {
+		Member leader = Member.builder().id(LEADER_ID).build();
+		StudyOnce studyOnce = makeStudy(leader, NOW.plusHours(4), NOW.plusHours(8), "오픈채팅방 링크");
+		assertDoesNotThrow(() -> studyOnce.changeMaxMemberCount(1));
+	}
+
+	@Test
 	@DisplayName("최대 참여 인원보다 현재 참석예정인 인원이 크다면 예외가 터진다.")
 	void validate_maxOrNowMemberCount_by_changeMaxMemberCount() {
 		Member leader = Member.builder().id(LEADER_ID).build();
+		Member member = Member.builder().id(MEMBER_ID).build();
 		StudyOnce studyOnce = StudyOnce.builder()
 			.name("스터디 이름")
 			.startDateTime(NOW.plusHours(4))
@@ -322,8 +343,9 @@ class StudyOnceTest {
 			.leader(leader)
 			.openChatUrl("오픈채팅방 링크")
 			.build();
+		studyOnce.tryJoin(member, NOW);
 
-		assertThatThrownBy(() -> studyOnce.changeMaxMemberCount(0))
+		assertThatThrownBy(() -> studyOnce.changeMaxMemberCount(1))
 			.isInstanceOf(CafegoryException.class)
 			.hasMessage(STUDY_ONCE_CANNOT_REDUCE_BELOW_CURRENT.getErrorMessage());
 	}


### PR DESCRIPTION
# 반영 브랜치
main
# 변경 사항

- 카공 최대인원 검증로직 수정
- 카공 생성시 최대인원 검증로직 적용
- 카공 수정시 최대인원 검증로직 적용

close #105